### PR TITLE
Stop redirecting all IO to log.

### DIFF
--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -25,7 +25,6 @@ module EmailAlertService
       logfile = File.open(app_root+"log/#{environment}.log", "a")
 
       logfile.sync = true
-      $stderr = $stdout = logfile
 
       @logger ||= Logger.new(logfile, "daily")
     end


### PR DESCRIPTION
We use the logger directly now.
