### PR TITLE
Ensure errors include document representation

### DIFF
--- a/email_alert_service/models/message.rb
+++ b/email_alert_service/models/message.rb
@@ -14,8 +14,8 @@ class Message
     else
       raise MalformedDocumentError.new(parsed_document)
     end
-  rescue JSON::ParserError => e
-    raise MalformedDocumentError.new(e.message)
+  rescue JSON::ParserError
+    raise MalformedDocumentError.new(@document_json)
   end
 
   def delivery_tag


### PR DESCRIPTION
Errors now include either the document JSON payload from RabbitMQ message
or the parsed JSON from the system.

This allows us to both analyse "bad" messages running in the RabbitMQ queue and messages that the system doesn't consider valid internally (for example, correctly formed JSON that is missing required keys)
