### PR TITLE
Strip blank tag arrays.

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -14,7 +14,7 @@ class EmailAlert
     {
       "subject" => document["title"],
       "body" => format_email_body,
-      "tags" => document["details"]["tags"],
+      "tags" => strip_empty_arrays(document["details"]["tags"]),
     }
   end
 
@@ -36,5 +36,11 @@ private
 
   def make_url_from_document_base_path
     Plek.new.website_root
+  end
+
+  def strip_empty_arrays(tag_hash)
+    tag_hash.reject {|_, tags|
+      tags.empty?
+    }
   end
 end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -38,8 +38,9 @@ RSpec.describe EmailAlert do
         "details" => {
           "change_note" => "this doc has been changed",
           "tags" => {
-            "browse_pages" => [],
-            "topics" => [],
+            "browse_pages" => ["tax/vat"],
+            "topics" => ["oil-and-gas/licensing"],
+            "some_other_missing_tags" => [],
           }
         }
       }
@@ -51,8 +52,8 @@ RSpec.describe EmailAlert do
         "subject" => document["title"],
         "body" => "HTML formatted body",
         "tags" => {
-          "browse_pages" => [],
-          "topics" => [],
+          "browse_pages" => ["tax/vat"],
+          "topics" => ["oil-and-gas/licensing"],
         },
       }
 


### PR DESCRIPTION
They're considered invalid by the email alert API.
