### PR TITLE
Changes formatting of public updated at sent in alert

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -45,6 +45,6 @@ private
   end
 
   def formatted_public_updated_at
-    DateTime.parse(document["public_updated_at"]).strftime("%I:%M%P, %-d %B %Y")
+    DateTime.parse(document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
   end
 end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe EmailAlert do
           <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
             <a href="#{url_from_document_base_path}" style="font-weight: bold; ">#{document["title"]}</a>
           </div>
-          01:39pm, 6 October 2014
+           1:39pm, 6 October 2014
           #{document["details"]["change_note"]}
           <br />
           <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{document["description"]}</div>


### PR DESCRIPTION
Provides more readable form of timestamp included in email alert body.

Format chosen according to GOV.UK Style Guide.
