### PR TITLE
Update bunny GEM to version 1.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "airbrake", "4.1.0"
-gem "bunny", "~> 1.3.1"
+gem 'bunny', "~> 1.5.0"
 gem "gds-api-adapters", "14.10.0"
 gem "plek", "1.9.0"
 gem "sidekiq", "3.2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
       multi_json
     amq-protocol (1.9.2)
     builder (3.2.2)
-    bunny (1.3.1)
+    bunny (1.5.1)
       amq-protocol (>= 1.9.2)
     byebug (3.4.0)
       columnize (~> 0.8)
@@ -74,7 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (= 4.1.0)
-  bunny (~> 1.3.1)
+  bunny (~> 1.5.0)
   byebug
   gds-api-adapters (= 14.10.0)
   plek (= 1.9.0)


### PR DESCRIPTION
Various fixes have happened since version 1.3.1, but the primary
motivation for upgrading is to get some improvements to reliability of
reconnection to the Rabbit cluster on failure.  In particular, this
allows a list of hosts to be passed to Bunny.new(), instead of a single
one, removing a single point of failure.
