### PR TITLE
Only log exits to Airbrake on StandardError

### DIFF
--- a/bin/email_alert_service
+++ b/bin/email_alert_service
@@ -26,7 +26,7 @@ end
 
 begin
   listener.listen
-rescue Exception => e
+rescue StandardError => e
   Airbrake.notify_or_ignore(e)
   raise e
 end


### PR DESCRIPTION
Previously, this was logging on any exit due to any Exception, which
means I was getting an email from Errbit each time the app was restarted
(ie, stopped by a signal, raising SignalException).
