### PR TITLE
Fix missing key errors in LockHandler

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -7,7 +7,10 @@ class EmailAlert
 
   def trigger
     @logger.info "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}"
-    @worker.perform_async(format_for_email_api)
+    @worker.perform_async({
+      "formatted" => format_for_email_api,
+      "public_updated_at" => document.fetch("public_updated_at"),
+    })
   end
 
   def format_for_email_api

--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -3,10 +3,9 @@ class LockHandler
   SECONDS_IN_A_DAY = 86400.freeze
   VALID_LOCK_PERIOD_IN_SECONDS = (90 * SECONDS_IN_A_DAY).freeze
 
-  def initialize(formatted_email)
-    @formatted_email = formatted_email
-    @formatted_email_title = formatted_email.fetch("title")
-    @formatted_email_updated_at = formatted_email.fetch("public_updated_at")
+  def initialize(email_title, public_updated_at)
+    @email_title = email_title
+    @public_updated_at = public_updated_at
   end
 
   def validate_and_set_lock
@@ -19,39 +18,39 @@ class LockHandler
 
 private
 
-  attr_reader :formatted_email, :formatted_email_title, :formatted_email_updated_at
+  attr_reader :email_title, :public_updated_at
 
   def log_key_status(key_status)
     unless key_status
-      logger.info "A lock for the message with title: #{formatted_email_title} and email_updated_at: #{formatted_email_updated_at} already exists"
+      logger.info "A lock for the message with title: #{email_title} and public_updated_at: #{public_updated_at} already exists"
     end
   end
 
   def set_lock_with_expiry
     redis.multi do
-      redis.setnx lock_key_id, formatted_email_title
+      redis.setnx lock_key_id, email_title
       redis.expireat lock_key_id, lock_expiry_period
     end
   end
 
   def lock_key_id
-    @_lock_key_id ||= Digest::SHA1.hexdigest formatted_email_title + formatted_email_updated_at
+    @_lock_key_id ||= Digest::SHA1.hexdigest email_title + public_updated_at
   end
 
   def within_valid_lock_period?
-    seconds_since_formatted_email_updated_at < VALID_LOCK_PERIOD_IN_SECONDS
+    seconds_since_public_updated_at < VALID_LOCK_PERIOD_IN_SECONDS
   end
 
   def lock_expiry_period
-    formatted_email_updated_at_in_seconds + VALID_LOCK_PERIOD_IN_SECONDS
+    public_updated_at_in_seconds + VALID_LOCK_PERIOD_IN_SECONDS
   end
 
-  def formatted_email_updated_at_in_seconds
-    Time.parse(formatted_email_updated_at).to_i
+  def public_updated_at_in_seconds
+    Time.parse(public_updated_at).to_i
   end
 
-  def seconds_since_formatted_email_updated_at
-    Time.now.to_i - formatted_email_updated_at_in_seconds
+  def seconds_since_public_updated_at
+    Time.now.to_i - public_updated_at_in_seconds
   end
 
   def redis

--- a/email_alert_service/workers/email_alert_worker.rb
+++ b/email_alert_service/workers/email_alert_worker.rb
@@ -4,8 +4,13 @@ require "models/lock_handler"
 class EmailAlertWorker
   include Sidekiq::Worker
 
-  def perform(formatted_email)
-    lock_handler = LockHandler.new(formatted_email)
+  def perform(email)
+    public_updated_at = email.fetch("public_updated_at")
+    formatted_email = email.fetch("formatted")
+    lock_handler = LockHandler.new(
+      formatted_email.fetch("subject"),
+      public_updated_at,
+    )
 
     if lock_handler.validate_and_set_lock
       email_api_client.send_alert(formatted_email)

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -3,7 +3,11 @@ require "spec_helper"
 RSpec.describe EmailAlert do
   describe "#trigger" do
     it "logs receiving a major change notification for a document" do
-      document = { "title" => "document title", "details" => { "tags" => { "topics" => ["a topic"]  } } }
+      document = {
+        "title" => "document title",
+        "details" => { "tags" => { "topics" => ["a topic"]  } },
+        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      }
       logger = double(:logger, info: nil)
       worker = double(:worker, perform_async: nil)
       email_alert = EmailAlert.new(document, logger, worker)
@@ -16,14 +20,21 @@ RSpec.describe EmailAlert do
     end
 
     it "queues a formatted alert in the worker" do
-      document = { "title" => "document title", "details" => { "tags" => { "topics" => ["a topic"]  } } }
+      document = {
+        "title" => "document title",
+        "details" => { "tags" => { "topics" => ["a topic"]  } },
+        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      }
       logger = double(:logger, info: nil)
       worker = double(:worker)
       formatted_for_email_api = double(:formatted_for_email_api)
       email_alert = EmailAlert.new(document, logger, worker)
       allow(email_alert).to receive(:format_for_email_api).and_return(formatted_for_email_api)
 
-      expect(worker).to receive(:perform_async).with(formatted_for_email_api)
+      expect(worker).to receive(:perform_async).with({
+        "formatted" => formatted_for_email_api,
+        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      })
 
       email_alert.trigger
     end

--- a/spec/models/lock_handler_spec.rb
+++ b/spec/models/lock_handler_spec.rb
@@ -1,7 +1,12 @@
 require "spec_helper"
 
 RSpec.describe LockHandler do
-  let(:lock_handler) { LockHandler.new(formatted_email) }
+  let(:lock_handler) {
+    LockHandler.new(
+      email_data["formatted"]["subject"],
+      email_data["public_updated_at"],
+    )
+  }
 
   before :each do
     allow(Redis).to receive(:new).and_return(mock_redis)
@@ -31,7 +36,7 @@ RSpec.describe LockHandler do
 
       it "logs a message if the lock is already set" do
         mock_logger = double
-        logger_message = "A lock for the message with title: #{formatted_email["title"]} and email_updated_at: #{formatted_email["public_updated_at"]} already exists"
+        logger_message = "A lock for the message with title: #{email_data["formatted"]["subject"]} and public_updated_at: #{email_data["public_updated_at"]} already exists"
 
         allow_any_instance_of(LockHandler).to receive(:logger).and_return(mock_logger)
         expect(mock_logger).to receive(:info).with(logger_message)
@@ -44,7 +49,10 @@ RSpec.describe LockHandler do
 
     context "if formatted email has expired" do
       it "checks that the  formatted email is within the valid expiry period" do
-        lock_handler = LockHandler.new(expired_formatted_email)
+        lock_handler = LockHandler.new(
+          expired_email_data["formatted"]["subject"],
+          expired_email_data["public_updated_at"],
+        )
 
         expect(lock_handler).to receive(:within_valid_lock_period?).and_call_original
         expect(lock_handler).to_not receive(:set_lock_with_expiry)

--- a/spec/support/lock_handler_test_helpers.rb
+++ b/spec/support/lock_handler_test_helpers.rb
@@ -14,22 +14,22 @@ module LockHandlerTestHelpers
   end
 
   def expired_date
-    Time.at(ninety_days_before(updated_now)).strftime("%l:%M%P, %-d %B %Y")
+    Time.at(ninety_days_before(updated_now)).iso8601
   end
 
   def updated_now
-    Time.now.strftime("%l:%M%P, %-d %B %Y")
+    Time.now.iso8601
   end
 
-  def expired_formatted_email
-    { "title" => "Example Alert", "public_updated_at" => expired_date }
+  def expired_email_data
+    { "formatted" => { "subject" => "Example Alert" }, "public_updated_at" => expired_date }
   end
 
-  def formatted_email
-    { "title" => "Example Alert", "public_updated_at" => updated_now }
+  def email_data
+    { "formatted" => { "subject" => "Example Alert" }, "public_updated_at" => updated_now }
   end
 
-  def lock_key_for_formatted_email
-    Digest::SHA1.hexdigest formatted_email["title"] + formatted_email["public_updated_at"]
+  def lock_key_for_email_data
+    Digest::SHA1.hexdigest email_data["formatted"]["subject"] + email_data["public_updated_at"]
   end
 end


### PR DESCRIPTION
No messages are currently being sent because the LockHandler expects to
be able to get `title` and `public_updated_at` keys from the hash passed
to the sidekiq worker, but the worker is only being passed the "formatted
email" (which has `subject` and `body` keys).

This commit fixes this by changing the format of the messages passed to
the sidekiq worker to include a `public_updated_at` key, and to move the
existing data under a `formatted` key:

```
{
  "formatted" => {
    "subject" => "foo",
    "body" => "bar"
  },
  "public_updated_at" => timestamp
}
```

The LockHandler is changed to expect to be given a title and ISO-format
timestamp, instead of just the whole sidekiq message.  I think it's best
to explicitly give it the values it needs to form its lock key, rather
than leave it to extract that from the sidekiq message, since this keeps
the interpretation of the values in the sidekiq message in one part of
the code.

The LockHandler tests were assuming that `public_updated_at` would be a
human readable timestamp - it should actually be an ISO format timestamp
(coming from the content-store), so while updating the tests I changed
the test values to be ISO format, too.

I also fixed the "does not send an email if there is an existing lock
key" LockHandler test to require that the email is sent exactly once,
rather than at most once, and also to use a time relative to now rather
than a fixed timestamp.  In about 3 months, this test would have stopped
calling the method in question at all, since we don't attempt to send
messages if they're older than 3 months, but the test would have
continued to pass.

We'll want to purge the sidekiq queues after deploying this, since the
existing messages on them don't have enough information to be processed
correctly.  This should be fine since there is no public link to the
email signup pages yet, so only test users should be subscribed.

Story: https://www.pivotaltracker.com/story/show/82049012
