### PR TITLE
Preserves formatted_email structure

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -7,17 +7,15 @@ class EmailAlert
 
   def trigger
     @logger.info "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}"
-    @worker.perform_async({
-      "formatted" => format_for_email_api,
-      "public_updated_at" => document.fetch("public_updated_at"),
-    })
+    @worker.perform_async(format_for_email_api)
   end
 
   def format_for_email_api
     {
-      "subject" => document["title"],
+      "subject" => document.fetch("title"),
       "body" => format_email_body,
       "tags" => strip_empty_arrays(document["details"]["tags"]),
+      "public_updated_at" => document.fetch("public_updated_at"),
     }
   end
 

--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -3,9 +3,9 @@ class LockHandler
   SECONDS_IN_A_DAY = 86400.freeze
   VALID_LOCK_PERIOD_IN_SECONDS = (90 * SECONDS_IN_A_DAY).freeze
 
-  def initialize(email_title, public_updated_at)
-    @email_title = email_title
-    @public_updated_at = public_updated_at
+  def initialize(formatted_email)
+    @email_title = formatted_email.fetch("subject")
+    @public_updated_at = formatted_email.fetch("public_updated_at")
   end
 
   def validate_and_set_lock

--- a/email_alert_service/workers/email_alert_worker.rb
+++ b/email_alert_service/workers/email_alert_worker.rb
@@ -4,13 +4,8 @@ require "models/lock_handler"
 class EmailAlertWorker
   include Sidekiq::Worker
 
-  def perform(email)
-    public_updated_at = email.fetch("public_updated_at")
-    formatted_email = email.fetch("formatted")
-    lock_handler = LockHandler.new(
-      formatted_email.fetch("subject"),
-      public_updated_at,
-    )
+  def perform(formatted_email)
+    lock_handler = LockHandler.new(formatted_email)
 
     if lock_handler.validate_and_set_lock
       email_api_client.send_alert(formatted_email)

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -31,10 +31,7 @@ RSpec.describe EmailAlert do
       email_alert = EmailAlert.new(document, logger, worker)
       allow(email_alert).to receive(:format_for_email_api).and_return(formatted_for_email_api)
 
-      expect(worker).to receive(:perform_async).with({
-        "formatted" => formatted_for_email_api,
-        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
-      })
+      expect(worker).to receive(:perform_async).with(formatted_for_email_api)
 
       email_alert.trigger
     end
@@ -72,6 +69,7 @@ RSpec.describe EmailAlert do
           <br />
           <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{document["description"]}</div>
         </div> ),
+        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
         "tags" => {
           "browse_pages" => ["tax/vat"],
           "topics" => ["oil-and-gas/licensing"],

--- a/spec/models/lock_handler_spec.rb
+++ b/spec/models/lock_handler_spec.rb
@@ -2,10 +2,7 @@ require "spec_helper"
 
 RSpec.describe LockHandler do
   let(:lock_handler) {
-    LockHandler.new(
-      email_data["formatted"]["subject"],
-      email_data["public_updated_at"],
-    )
+    LockHandler.new(email_data)
   }
 
   before :each do
@@ -36,7 +33,7 @@ RSpec.describe LockHandler do
 
       it "logs a message if the lock is already set" do
         mock_logger = double
-        logger_message = "A lock for the message with title: #{email_data["formatted"]["subject"]} and public_updated_at: #{email_data["public_updated_at"]} already exists"
+        logger_message = "A lock for the message with title: #{email_data["subject"]} and public_updated_at: #{email_data["public_updated_at"]} already exists"
 
         allow_any_instance_of(LockHandler).to receive(:logger).and_return(mock_logger)
         expect(mock_logger).to receive(:info).with(logger_message)
@@ -49,10 +46,7 @@ RSpec.describe LockHandler do
 
     context "if formatted email has expired" do
       it "checks that the  formatted email is within the valid expiry period" do
-        lock_handler = LockHandler.new(
-          expired_email_data["formatted"]["subject"],
-          expired_email_data["public_updated_at"],
-        )
+        lock_handler = LockHandler.new(expired_email_data)
 
         expect(lock_handler).to receive(:within_valid_lock_period?).and_call_original
         expect(lock_handler).to_not receive(:set_lock_with_expiry)

--- a/spec/support/lock_handler_test_helpers.rb
+++ b/spec/support/lock_handler_test_helpers.rb
@@ -22,14 +22,14 @@ module LockHandlerTestHelpers
   end
 
   def expired_email_data
-    { "formatted" => { "subject" => "Example Alert" }, "public_updated_at" => expired_date }
+    { "subject" => "Example Alert", "public_updated_at" => expired_date }
   end
 
   def email_data
-    { "formatted" => { "subject" => "Example Alert" }, "public_updated_at" => updated_now }
+    { "subject" => "Example Alert", "public_updated_at" => updated_now }
   end
 
   def lock_key_for_email_data
-    Digest::SHA1.hexdigest email_data["formatted"]["subject"] + email_data["public_updated_at"]
+    Digest::SHA1.hexdigest email_data["subject"] + email_data["public_updated_at"]
   end
 end

--- a/spec/workers/email_alert_worker_spec.rb
+++ b/spec/workers/email_alert_worker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EmailAlertWorker do
 
   describe "#perform(email_data)" do
     it "sends the formatted email to the email API client" do
-      expect(email_api_client).to receive(:send_alert).with(email_data["formatted"])
+      expect(email_api_client).to receive(:send_alert).with(email_data)
 
       worker.perform(email_data)
     end
@@ -21,7 +21,7 @@ RSpec.describe EmailAlertWorker do
     aproximate_expiry_period_in_seconds = 770000
 
     allow_any_instance_of(LockHandler).to receive(:validate_and_set_lock).and_call_original
-    expect(email_api_client).to receive(:send_alert).with(email_data["formatted"])
+    expect(email_api_client).to receive(:send_alert).with(email_data)
 
     worker.perform(email_data)
 
@@ -34,11 +34,11 @@ RSpec.describe EmailAlertWorker do
 
   it "does not send an email if there is an existing lock key" do
     email_data_with_set_time = {
-      "formatted" => { "subject" => "Example Alert" },
+      "subject" => "Example Alert",
       "public_updated_at" => updated_now
     }
 
-    expect(email_api_client).to receive(:send_alert).with(email_data_with_set_time["formatted"]).exactly(:once)
+    expect(email_api_client).to receive(:send_alert).with(email_data_with_set_time).exactly(:once)
 
     2.times do
       worker.perform(email_data_with_set_time)


### PR DESCRIPTION
This builds on the work and comments made in https://github.com/alphagov/email-alert-service/pull/24.

Discussion copied from there:

I would prefer to add the "public_updated_at" to EmailAlert#format_for_email_api and pass that structure around (both to the worker and to the lock handler).

Preserving the whole structure will avoid assign additional local variables in the worker and leave both classes open for extension. We also risk introducing shotgun surgery otherwise, since any changes in format email will result in changes to instantiating the lock handler in the worker.

It will also prevent churn caused by the introduction of the "formatted" key, that does not seem to bring any benefits.

We should also look to be consistent in the way hashes are accessed - happy to move to fetch but consistently.
