### PR TITLE
Include the base_path when building document URLs

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -38,7 +38,7 @@ private
   end
 
   def make_url_from_document_base_path
-    Plek.new.website_root
+    Plek.new.website_root + document["base_path"]
   end
 
   def strip_empty_arrays(tag_hash)

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe EmailAlert do
   describe "#format_for_email_api" do
     it "formats the message to send to the email alert api" do
       document = {
+        "base_path" => "/foo",
         "title" => "Example title",
         "description" => "example description",
         "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
@@ -59,7 +60,7 @@ RSpec.describe EmailAlert do
       logger = double(:logger)
       worker = double(:worker)
 
-      url_from_document_base_path = Plek.new.website_root
+      url_from_document_base_path = Plek.new.website_root + document["base_path"]
 
       formatted_message = {
         "subject" => document["title"],


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82041078

At the moment, the URL that we link to from the document title in email alerts only include the Plek `website_root`.

This changes the `EmailAlert` model so that the value of the `base_path` document attribute is appended to `website_root`. 

This means that users will be linked to the full content item on GOV.UK, rather than the homepage.
