### PR TITLE
Use correct redis configuration in LockHandler

### DIFF
--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -54,7 +54,7 @@ private
   end
 
   def redis
-    @_redis ||= Redis.new
+    @_redis ||= Redis.new(EmailAlertService.config.redis_config)
   end
 
   def logger


### PR DESCRIPTION
Previously the LockHandler was just attempting to connect to redis with
the default config, which works when redis is running locally.  In
production, redis is not running locally, so we need to pass the proper
configuration in.
