### PR TITLE
Ignore heartbeat messages based on content type.

### DIFF
--- a/email_alert_service/listeners/listener.rb
+++ b/email_alert_service/listeners/listener.rb
@@ -5,8 +5,8 @@ class Listener
   end
 
   def listen
-    @queue_binding.subscribe(block: true, manual_ack: true) do |delivery_info, _, document_json|
-      @processor.process(document_json, delivery_info)
+    @queue_binding.subscribe(block: true, manual_ack: true) do |delivery_info, properties, document_json|
+      @processor.process(document_json, properties, delivery_info)
     end
   end
 end

--- a/email_alert_service/models/message.rb
+++ b/email_alert_service/models/message.rb
@@ -2,8 +2,9 @@ require "json"
 require "validators/document_validator"
 
 class Message
-  def initialize(document_json, delivery_info)
+  def initialize(document_json, properties, delivery_info)
     @delivery_info = delivery_info
+    @properties = properties
     @document_json = document_json
   end
 
@@ -20,6 +21,10 @@ class Message
 
   def delivery_tag
     @delivery_info.delivery_tag
+  end
+
+  def heartbeat?
+    @properties.content_type == "application/x-heartbeat"
   end
 
 private

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -8,10 +8,14 @@ class MessageProcessor
     @logger = logger
   end
 
-  def process(document_json, delivery_info)
-    message = Message.new(document_json, delivery_info)
-    document = message.validate_document
-    trigger_email_alert(document) if tagged_to_topics?(document)
+  def process(document_json, properties, delivery_info)
+    message = Message.new(document_json, properties, delivery_info)
+
+    unless message.heartbeat?
+      document = message.validate_document
+      trigger_email_alert(document) if tagged_to_topics?(document)
+    end
+
     acknowledge(message)
   rescue MalformedDocumentError => e
     Airbrake.notify_or_ignore(e)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/82552398

Simply receiving them is enough for our monitoring to be able to detect inactive consumers, so we don't need to do any further processing.

In the tests I've used a fully formed document message where normally there would be a cut-down heartbeat message, because I want to prove that the code is ignoring the message based on the content type and not because it doesn't currently conform to spec (messages without topics are currently ignored).
