### PR TITLE
Ignore messages which aren't in the english locale

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -12,7 +12,14 @@ class MessageProcessor
 
     unless message.heartbeat?
       document = message.validate_document
-      trigger_email_alert(document) if tagged_to_topics?(document)
+      if tagged_to_topics?(document)
+        if is_english?(document)
+          @logger.info "triggering email alert for document #{document["title"]}"
+          trigger_email_alert(document)
+        else
+          @logger.info "not triggering email alert for non-english document #{document["title"]}: locale #{document["locale"]}"
+        end
+      end
     end
 
     acknowledge(message)
@@ -36,6 +43,10 @@ private
     else
       false
     end
+  end
+
+  def is_english?(document)
+    document.fetch("locale", "en") == "en"
   end
 
   def acknowledge(message)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -73,6 +73,41 @@ RSpec.describe MessageProcessor do
       }'
     }
 
+  let(:tagged_english_document) {
+    '{
+        "base_path": "path/to-doc",
+        "title": "Example title",
+        "description": "example description",
+        "locale": "en",
+        "public_updated_at": "2014-10-06T13:39:19.000+00:00",
+        "details": {
+          "change_note": "this doc has been changed",
+          "tags": {
+            "browse_pages": [],
+            "topics": ["example topic one", "example topic two"]
+          }
+        }
+      }'
+    }
+
+  let(:tagged_french_document) {
+    '{
+        "base_path": "path/to-doc",
+        "title": "Le title",
+        "description": "pour example",
+        "locale": "fr",
+        "public_updated_at": "2014-10-06T13:39:19.000+00:00",
+        "details": {
+          "change_note": "this doc has been changed, un petit peu",
+          "tags": {
+            "browse_pages": [],
+            "topics": ["example topic one", "example topic two"]
+          }
+        }
+      }'
+    }
+
+
   describe "#process(document_json, delivery_info)" do
     it "acknowledges and triggers the message if the document has topics" do
       expect(processor).to receive(:trigger_email_alert)
@@ -138,6 +173,26 @@ RSpec.describe MessageProcessor do
 
 
       expect(channel).to have_received(:acknowledge).with(delivery_tag, false)
+    end
+
+    it "acknowledges and triggers the message if the document has topics and is english" do
+      expect(processor).to receive(:trigger_email_alert)
+      processor.process(tagged_english_document, properties, delivery_info)
+
+      expect(channel).to have_received(:acknowledge).with(
+        delivery_tag,
+        false
+      )
+    end
+
+    it "ignores the message if the document has topics but is not english" do
+      expect(processor).not_to receive(:trigger_email_alert)
+      processor.process(tagged_french_document, properties, delivery_info)
+
+      expect(channel).to have_received(:acknowledge).with(
+        delivery_tag,
+        false
+      )
     end
   end
 end


### PR DESCRIPTION
Content-store will shortly be recieving messages from whitehall in
non-english locales.  For now, we'll simply ignore any messages which
aren't in english.

This is the same approach as taken by the content-register for now: https://github.com/alphagov/content-register/pull/18
