### PR TITLE
Inject an identifier into email body

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -36,7 +36,7 @@ private
   end
 
   def format_email_body
-    %Q( <div class="rss_item" style="margin-bottom: 2em;">
+    %Q( <div class="rss_item" data-message-id="#{document_identifier_hash}" style="margin-bottom: 2em;">
           <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
             <a href="#{make_url_from_document_base_path}" style="font-weight: bold; ">#{document["title"]}</a>
           </div>
@@ -59,5 +59,9 @@ private
 
   def formatted_public_updated_at
     DateTime.parse(document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
+  end
+
+  def document_identifier_hash
+    MessageIdentifier.new(document["title"], document["public_updated_at"]).create
   end
 end

--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'models/message_identifier'
 
 class LockHandler
 
@@ -82,7 +83,7 @@ private
   end
 
   def message_key
-    @_message_key ||= Digest::SHA1.hexdigest(email_title + public_updated_at)
+    @_message_key ||= MessageIdentifier.new(email_title, public_updated_at).create
   end
 
   def within_marker_period?

--- a/email_alert_service/models/message_identifier.rb
+++ b/email_alert_service/models/message_identifier.rb
@@ -1,0 +1,17 @@
+class MessageIdentifier
+  def initialize(title, timestamp)
+    @title = title
+    @timestamp = timestamp
+  end
+
+  def create
+    create_hexdigest
+  end
+
+private
+  attr_reader :title, :timestamp
+
+  def create_hexdigest
+    Digest::SHA1.hexdigest(title + timestamp)
+  end
+end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe EmailAlert do
 
       formatted_message = {
         "subject" => document["title"],
-        "body" => %Q( <div class="rss_item" style="margin-bottom: 2em;">
+        "body" => %Q( <div class="rss_item" data-message-id="#{identifier_hash_for(document)}" style="margin-bottom: 2em;">
           <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
             <a href="#{url_from_document_base_path}" style="font-weight: bold; ">#{document["title"]}</a>
           </div>

--- a/spec/models/message_identifier_spec.rb
+++ b/spec/models/message_identifier_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe MessageIdentifier, "#create" do
+  it "generates a hexdigest from a title and timestamp" do
+    expected_hexdigest = Digest::SHA1.hexdigest("a title" + Time.now.iso8601)
+
+    generated_hexdigest = MessageIdentifier.new("a title", Time.now.iso8601).create
+
+    expect(expected_hexdigest).to eq generated_hexdigest
+  end
+end

--- a/spec/support/lock_handler_test_helpers.rb
+++ b/spec/support/lock_handler_test_helpers.rb
@@ -25,8 +25,15 @@ module LockHandlerTestHelpers
     { "formatted" => { "subject" => "Example Alert" }, "public_updated_at" => updated_now.iso8601 }
   end
 
+  def identifier_hash_for(document)
+    Digest::SHA1.hexdigest(document["title"] + document["public_updated_at"])
+  end
+
   def message_key_for_email_data
-    Digest::SHA1.hexdigest(email_data["formatted"]["subject"] + email_data["public_updated_at"])
+    MessageIdentifier.new(
+      email_data["formatted"]["subject"],
+      email_data["public_updated_at"]
+    ).create
   end
 
   def lock_key_for_email_data


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/84134884

In order to able to compare sent and received emails via the Email alert monitor, we need
to inject an identifier into the email body.

This PR reuses the implementation for generating an identifier for a
message in Redis, injecting it into the wrapper div in the email body
with a `data-message-id` attribute. The use of an HTML data-attribute tries to
make it easier to retrieve the identifier in other apps, such as the
Email alert monitor.
