### PR TITLE
Upgrade rack to 1.6.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     multi_json (1.10.1)
     null_logger (0.0.1)
     plek (1.9.0)
-    rack (1.5.2)
+    rack (1.6.2)
     rack-cache (1.2)
       rack (>= 0.4)
     rdoc (4.1.2)


### PR DESCRIPTION
Rack is used by the gds-adapter-gem, so this application is not vulnerable to the recent rack CVE, but upgrade anyhow.

https://groups.google.com/forum/#!msg/rubyonrails-security/gcUbICUmKMc/qiCotVZwXrMJ