### PR TITLE
Handle messages with no title or description

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -14,8 +14,12 @@ class MessageProcessor
       document = message.validate_document
       if tagged_to_topics?(document)
         if is_english?(document)
-          @logger.info "triggering email alert for document #{document["title"]}"
-          trigger_email_alert(document)
+          if has_title?(document)
+            @logger.info "triggering email alert for document #{document["title"]}"
+            trigger_email_alert(document)
+          else
+            @logger.info "not triggering email alert for document with no title: #{document}"
+          end
         else
           @logger.info "not triggering email alert for non-english document #{document["title"]}: locale #{document["locale"]}"
         end
@@ -47,6 +51,10 @@ private
 
   def is_english?(document)
     document.fetch("locale", "en") == "en"
+  end
+
+  def has_title?(document)
+    document.fetch("title", "") != ""
   end
 
   def acknowledge(message)

--- a/email_alert_service/validators/document_validator.rb
+++ b/email_alert_service/validators/document_validator.rb
@@ -1,5 +1,5 @@
 class DocumentValidator
-  REQUIRED_KEYS = %w(base_path title description public_updated_at details).freeze
+  REQUIRED_KEYS = %w(base_path public_updated_at details).freeze
 
   def initialize(document)
     @document = document

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -107,6 +107,21 @@ RSpec.describe MessageProcessor do
       }'
     }
 
+  let(:tagged_untitled_document) {
+    '{
+        "base_path": "path/to-doc",
+        "locale": "en",
+        "public_updated_at": "2014-10-06T13:39:19.000+00:00",
+        "details": {
+          "change_note": "this doc has been changed",
+          "tags": {
+            "browse_pages": [],
+            "topics": ["example topic one", "example topic two"]
+          }
+        }
+      }'
+    }
+
 
   describe "#process(document_json, delivery_info)" do
     it "acknowledges and triggers the message if the document has topics" do
@@ -188,6 +203,16 @@ RSpec.describe MessageProcessor do
     it "ignores the message if the document has topics but is not english" do
       expect(processor).not_to receive(:trigger_email_alert)
       processor.process(tagged_french_document, properties, delivery_info)
+
+      expect(channel).to have_received(:acknowledge).with(
+        delivery_tag,
+        false
+      )
+    end
+
+    it "ignores the message if the document has topics but no title" do
+      expect(processor).not_to receive(:trigger_email_alert)
+      processor.process(tagged_untitled_document, properties, delivery_info)
 
       expect(channel).to have_received(:acknowledge).with(
         delivery_tag,


### PR DESCRIPTION
This is in response to errors we've started getting with processing of
redirect documents (which have neither title nor description), and
organisation documents (which have no description).  These document
formats didn't exist in content-store when the service was initially
designed.  Further, until some recent changes in the publishing API,
even when the fields were absent from the document sent to the
publishing API, the message on the message queue had the fields present
with their values set to `nil`, so passed validation here.

"Content" documents should always have a title, so ignoring documents
without them is safe, and has the small benefit of ensuring that there's
no risk of things like "redirect" documents triggering alerts.  Sending
an alert for a document without a title would be uninformative anyway,
since the title is how we identify the document in the body of the
message.

If a document has a missing description field, we can still send a
useful message - it will just be missing the description of the
document.  Therefore, we allow messages to be sent in this case.

The code this touches could do with some refactoring, but I don't want
to get people distracted by that right now - I just want to fix the
immediate problems.