### PR TITLE
Don't error on redirect items.

### DIFF
--- a/email_alert_service/models/message.rb
+++ b/email_alert_service/models/message.rb
@@ -8,10 +8,15 @@ class Message
     @document_json = document_json
   end
 
-  def validate_document
-    valid_document = validate(parsed_document)
-    if valid_document
-      valid_document
+  def parsed_document
+    @_parsed_document ||= JSON.parse(@document_json)
+  rescue JSON::ParserError
+    raise MalformedDocumentError.new(@document_json)
+  end
+
+  def validate!
+    if DocumentValidator.new(parsed_document).valid?
+      parsed_document
     else
       raise InvalidDocumentError.new(parsed_document)
     end
@@ -23,20 +28,6 @@ class Message
 
   def heartbeat?
     @properties.content_type == "application/x-heartbeat"
-  end
-
-private
-
-  def validate(document)
-    if DocumentValidator.new(document).valid?
-      document
-    end
-  end
-
-  def parsed_document
-    JSON.parse(@document_json)
-  rescue JSON::ParserError
-    raise MalformedDocumentError.new(@document_json)
   end
 end
 

--- a/email_alert_service/models/message.rb
+++ b/email_alert_service/models/message.rb
@@ -13,10 +13,8 @@ class Message
     if valid_document
       valid_document
     else
-      raise MalformedDocumentError.new(parsed_document)
+      raise InvalidDocumentError.new(parsed_document)
     end
-  rescue JSON::ParserError
-    raise MalformedDocumentError.new(@document_json)
   end
 
   def delivery_tag
@@ -37,7 +35,10 @@ private
 
   def parsed_document
     JSON.parse(@document_json)
+  rescue JSON::ParserError
+    raise MalformedDocumentError.new(@document_json)
   end
 end
 
-class MalformedDocumentError < Exception; end
+class MalformedDocumentError < StandardError; end
+class InvalidDocumentError < StandardError; end

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -27,7 +27,7 @@ class MessageProcessor
     end
 
     acknowledge(message)
-  rescue MalformedDocumentError => e
+  rescue InvalidDocumentError, MalformedDocumentError => e
     Airbrake.notify_or_ignore(e)
     discard(delivery_info.delivery_tag)
   end

--- a/email_alert_service/validators/document_validator.rb
+++ b/email_alert_service/validators/document_validator.rb
@@ -1,5 +1,5 @@
 class DocumentValidator
-  REQUIRED_KEYS = %w(base_path public_updated_at details).freeze
+  REQUIRED_KEYS = %w(base_path title public_updated_at details).freeze
 
   def initialize(document)
     @document = document

--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Receiving major change notifications", type: :integration do
   }
 
   let(:malformed_json) { '{23o*&£}' }
-  let(:malformed_document) { '{"houses": "are for living in"}' }
+  let(:invalid_document) { '{"houses": "are for living in"}' }
 
   around :each do |example|
     start_listener
@@ -32,7 +32,7 @@ RSpec.describe "Receiving major change notifications", type: :integration do
     expect_any_instance_of(MessageProcessor).to receive(:discard).twice.and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).not_to receive(:send_alert)
 
-    send_message(malformed_document)
+    send_message(invalid_document)
     send_message(malformed_json)
 
     wait_for_messages_to_process

--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -28,12 +28,20 @@ RSpec.describe "Receiving major change notifications", type: :integration do
     stop_listener
   end
 
-  it "discards invalid documents" do
-    expect_any_instance_of(MessageProcessor).to receive(:discard).twice.and_call_original
+  it "discards malformed documents" do
+    expect_any_instance_of(MessageProcessor).to receive(:discard).once.and_call_original
+    expect_any_instance_of(GdsApi::EmailAlertApi).not_to receive(:send_alert)
+
+    send_message(malformed_json)
+
+    wait_for_messages_to_process
+  end
+
+  it "ignores invalid documents" do
+    expect_any_instance_of(MessageProcessor).to receive(:acknowledge).once.and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).not_to receive(:send_alert)
 
     send_message(invalid_document)
-    send_message(malformed_json)
 
     wait_for_messages_to_process
   end

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -122,6 +122,18 @@ RSpec.describe MessageProcessor do
       }'
     }
 
+  let(:redirect_item) {
+    '{
+      "base_path": "/foo",
+      "format": "redirect",
+      "publishing_app": "something",
+      "update_type": "major",
+      "redirects": [
+        {"path": "/foo", "destination": "/topic/foo", "type": "exact"}
+      ]
+    }'
+  }
+
 
   describe "#process(document_json, delivery_info)" do
     it "acknowledges and triggers the message if the document has topics" do
@@ -213,6 +225,16 @@ RSpec.describe MessageProcessor do
     it "ignores the message if the document has topics but no title" do
       expect(processor).not_to receive(:trigger_email_alert)
       processor.process(tagged_untitled_document, properties, delivery_info)
+
+      expect(channel).to have_received(:acknowledge).with(
+        delivery_tag,
+        false
+      )
+    end
+
+    it "ignores items without a public_updated_at" do
+      expect(processor).not_to receive(:trigger_email_alert)
+      processor.process(redirect_item, properties, delivery_info)
 
       expect(channel).to have_received(:acknowledge).with(
         delivery_tag,

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Message do
   let(:document_json) { double(:document_json) }
   let(:properties) { double(:properties, content_type: nil) }
 
-  describe "#validate_document" do
+  describe "#validate!" do
     it "returns a parsed, valid document" do
       document_json =
         '{
@@ -22,10 +22,21 @@ RSpec.describe Message do
             }
          }'
 
-      valid_json = JSON.parse(document_json)
+      valid_data = JSON.parse(document_json)
       message = Message.new(document_json, properties, delivery_info)
 
-      expect(message.validate_document).to eq valid_json
+      expect(message.validate!).to eq valid_data
+    end
+
+    it "raises given an invalid document" do
+      document_json =
+        '{ "hello": "something else" }'
+
+      message = Message.new(document_json, properties, delivery_info)
+
+      expect {
+        message.validate!
+      }.to raise_error(InvalidDocumentError)
     end
   end
 


### PR DESCRIPTION
Previously, this would error for items without a public_updated_at field
set (ie redirect or gone items).  This is because the check for the
presence of a title happens after the validation.

This has involved some refactoring of the message processor so that it
checks for the title and language before validating the document.