### PR TITLE
Handle messages which have no details hash

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -50,7 +50,7 @@ private
   end
 
   def tagged_to_topics?(document)
-    details = document.fetch("details")
+    details = document.fetch("details", {})
     if details.has_key?("tags") && details.fetch("tags").has_key?("topics")
       details.fetch("tags").fetch("topics").any?
     else

--- a/email_alert_service/validators/document_validator.rb
+++ b/email_alert_service/validators/document_validator.rb
@@ -1,5 +1,5 @@
 class DocumentValidator
-  REQUIRED_KEYS = %w(base_path title public_updated_at details).freeze
+  REQUIRED_KEYS = %w(base_path title public_updated_at).freeze
 
   def initialize(document)
     @document = document

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe MessageProcessor do
      }'
   }
 
+  let(:document_with_no_details_hash) {
+    '{
+        "base_path": "path/to-doc",
+        "title": "Example title",
+        "description": "example description",
+        "public_updated_at": "2014-10-06T13:39:19.000+00:00"
+     }'
+  }
+
   let(:tagged_document) {
     '{
         "base_path": "path/to-doc",
@@ -169,6 +178,16 @@ RSpec.describe MessageProcessor do
     it "acknowledges but doesnt trigger the message if the document does not have a topics key" do
       expect(processor).to_not receive(:trigger_email_alert)
       processor.process(document_with_no_topics_key, properties, delivery_info)
+
+      expect(channel).to have_received(:acknowledge).with(
+        delivery_tag,
+        false
+      )
+    end
+
+    it "acknowledges but doesnt trigger the message if the document does not have a details hash" do
+      expect(processor).to_not receive(:trigger_email_alert)
+      processor.process(document_with_no_details_hash, properties, delivery_info)
 
       expect(channel).to have_received(:acknowledge).with(
         delivery_tag,

--- a/spec/validators/document_validator_spec.rb
+++ b/spec/validators/document_validator_spec.rb
@@ -18,10 +18,23 @@ RSpec.describe DocumentValidator do
       }
     }
 
+    let(:valid_document_no_details) {
+      {
+        "base_path" => "path/to-doc",
+        "title" => "Example title",
+        "description" => "example description",
+        "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      }
+    }
+
     let(:invalid_document) { {"title" => "invalid document"} }
 
     it "returns true for a valid document" do
       expect(DocumentValidator.new(valid_document)).to be_valid
+    end
+
+    it "returns true for a valid document with no details hash" do
+      expect(DocumentValidator.new(valid_document_no_details)).to be_valid
     end
 
     it "returns false for an invalid document" do


### PR DESCRIPTION
Such messages can be valid (for example, the special_route documents are
valid items).

Rather than raising a validation error for such documents, just ignore
them.

Currently, such documents can never be tagged to topics (since
the topic tags are held in the details hash), but in future it will be
possible for them to be tagged using the links hash, so I've not
implemented this by actively ignoring the documents - instead, I've just
handled a missing details hash the same as one which is present but
empty.