### PR TITLE
DO NOT MERGE  Include correct URL in policy change notification mail

### DIFF
--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Receiving major change notifications", type: :integration do
   include LockHandlerTestHelpers
+  include ContentItemHelpers
 
   let(:well_formed_document) {
     {
@@ -21,8 +22,9 @@ RSpec.describe "Receiving major change notifications", type: :integration do
 
   let(:malformed_json) { '{23o*&£}' }
   let(:invalid_document) { '{"houses": "are for living in"}' }
-
+  
   around :each do |example|
+    system('GOVUK_ENV=test bin/delete_queue')
     start_listener
     example.run
     stop_listener
@@ -50,6 +52,11 @@ RSpec.describe "Receiving major change notifications", type: :integration do
     expect_any_instance_of(MessageProcessor).to receive(:acknowledge).and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
 
+    web_url = "https://www.gov.uk/content/policies/2012-olympic-and-paralympic-legacy"
+    stub_request(:get, "http://content-store.dev.gov.uk/contentpath/to-doc").
+      with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Content-Type'=>'application/json', 'User-Agent'=>'gds-api-adapters/20.1.1 ()'}).
+      to_return(:status => 200, :body => content_item(web_url), :headers => {})
+
     send_message(well_formed_document, routing_key: "policy.major")
 
     wait_for_messages_to_process
@@ -58,7 +65,7 @@ RSpec.describe "Receiving major change notifications", type: :integration do
   it "doesn't process documents for other change types" do
     expect_any_instance_of(MessageProcessor).not_to receive(:process)
     expect_any_instance_of(GdsApi::EmailAlertApi).not_to receive(:send_alert)
-
+    
     send_message(well_formed_document, routing_key: "policy.minor")
     send_message(well_formed_document, routing_key: "policy.republish")
 
@@ -66,6 +73,10 @@ RSpec.describe "Receiving major change notifications", type: :integration do
   end
 
   it "sends an email alert for documents experiencing major changes" do
+    web_url = "https://www.gov.uk/content/policies/2012-olympic-and-paralympic-legacy"
+    stub_request(:get, "http://content-store.dev.gov.uk/contentpath/to-doc").
+      with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Content-Type'=>'application/json', 'User-Agent'=>'gds-api-adapters/20.1.1 ()'}).
+      to_return(:status => 200, :body => content_item(web_url), :headers => {})
     expect_any_instance_of(MessageProcessor).to receive(:acknowledge).and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -2,44 +2,59 @@ require "spec_helper"
 
 RSpec.describe EmailAlert do
   include LockHandlerTestHelpers
+  include ContentItemHelpers
 
-  let(:document) {
+  let(:document) do
     {
-      "title" => generate_title,
-      "details" => { "tags" => { "topics" => ["a topic"]  } },
+      "base_path" => "/foo",
+      "title" => "Example title",
+      "details" => {
+        "tags" => {
+          "browse_pages" => ["tax/vat"],
+          "topics" => ["oil-and-gas/licensing"],
+          "some_other_missing_tags" => [],
+        }
+      },
       "public_updated_at" => updated_now.iso8601,
     }
-  }
+  end
+
+  class FakeLockHandler
+    def with_lock_unless_done
+      yield
+    end
+  end
 
   let(:logger) { double(:logger, info: nil) }
+  let(:alert_api) { double(:alert_api, send_alert: nil) }
   let(:email_alert) { EmailAlert.new(document, logger) }
+  let(:fake_lock_handler) { FakeLockHandler.new }
+
+  before do
+    allow(GdsApi::EmailAlertApi).to receive(:new).and_return(alert_api)
+    allow(LockHandler).to receive(:new).and_return(fake_lock_handler)
+  end
 
   describe "#trigger" do
     it "logs receiving a major change notification for a document" do
-      allow(email_alert).to receive(:format_for_email_api).and_return(nil)
-
-      expect(logger).to receive(:info).with(
-        "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}")
-
-      expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
-
       email_alert.trigger
+
+      expect(logger).to have_received(:info).with(
+        "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}"
+      )
     end
 
     it "sends an alert to the Email Alert API" do
-      formatted_for_email_api = double(:formatted_for_email_api)
-      allow(email_alert).to receive(:format_for_email_api).and_return(formatted_for_email_api)
-
-      expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
-
       email_alert.trigger
+
+      expect(alert_api).to have_received(:send_alert)
     end
   end
 
   describe "#format_for_email_api" do
     it "formats the message to send to the email alert api" do
       document = {
-        "base_path" => "/foo",
+        "base_path" => "an-important-policy/email-signup",
         "title" => "Example title",
         "description" => "example description",
         "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
@@ -53,7 +68,7 @@ RSpec.describe EmailAlert do
         }
       }
 
-      url_from_document_base_path = Plek.new.website_root + document["base_path"]
+      url_from_document_base_path = Plek.new.website_root + "an-important-policy"
 
       formatted_message = {
         "subject" => document["title"],
@@ -71,6 +86,11 @@ RSpec.describe EmailAlert do
           "topics" => ["oil-and-gas/licensing"],
         },
       }
+
+      web_url = "http://www.dev.gov.ukan-important-policy"
+      stub_request(:get, "http://content-store.dev.gov.uk/contentan-important-policy/email-signup").
+         with(:headers => {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip, deflate', 'Content-Type'=>'application/json', 'User-Agent'=>'gds-api-adapters/20.1.1 ()'}).
+         to_return(:status => 200, :body => content_item(web_url), :headers => {})
 
       email_alert = EmailAlert.new(document, logger)
 

--- a/spec/support/content_store_responses.rb
+++ b/spec/support/content_store_responses.rb
@@ -1,0 +1,57 @@
+module ContentItemHelpers
+
+  def content_item(web_url)
+    {
+      "base_path" => "/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+      "content_id"=>"404e4ebc-d413-44d6-b157-b70c118397d3",
+      "title"=>"2012 Olympic and Paralympic legacy",
+      "description"=>"",
+      "format"=>"email_alert_signup",
+      "need_ids"=>[],
+      "locale"=>"en",
+      "updated_at"=>"2015-11-05T13:06:52.413Z",
+      "public_updated_at"=>"2015-05-26T15:15:26.742+00:00",
+      "details"=>{
+        "breadcrumbs"=> [
+          {
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "link"=>"/government/policies/2012-olympic-and-paralympic-legacy"
+          }
+        ],
+        "summary"=>"\n      You'll get an email each time a document about\n      this policy is published or updated.\n    ",
+        "tags"=>{
+          "policy"=>[
+            "2012-olympic-and-paralympic-legacy"
+          ]
+        },
+        "govdelivery_title"=>"2012 Olympic and Paralympic legacy policy"
+      },
+      "phase"=>"live",
+      "analytics_identifier"=>nil,
+      "links"=>{
+        "parent"=>[
+          {
+            "content_id"=>"5d37821b-7631-11e4-a3cb-005056011aef",
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "base_path"=>"/government/policies/2012-olympic-and-paralympic-legacy",
+            "description"=>"",
+            "api_url"=>"https://www.gov.uk/api/content/government/policies/2012-olympic-and-paralympic-legacy",
+            "web_url"=> web_url,
+            "locale"=>"en"
+          }
+        ],
+        "available_translations"=>[
+          {
+            "content_id"=>"404e4ebc-d413-44d6-b157-b70c118397d3",
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "base_path"=>"/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "description"=>"",
+            "api_url"=>"https://www.gov.uk/api/content/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "web_url"=>"https://www.gov.uk/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "locale"=>"en"
+          }
+        ]
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
When a policy is changed, an email is sent to everyone who is subscribed to those notifications. Currently, the url included in this mail points to the sign-up for notifications page, and not to the policy itself. This change will correct this error.

Trello: https://trello.com/c/JExeIwcb