### PR TITLE
Conditionally include links hash in call to email-alert-api

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -17,10 +17,21 @@ class EmailAlert
 
   def format_for_email_api
     {
+    api_params = {
       "subject" => document["title"],
       "body" => format_email_body,
       "tags" => strip_empty_arrays(document["details"]["tags"]),
     }
+
+    # FIXME: this conditional check on links should be considered temporary.
+    # Eventually we want all email alerts to be triggered via content IDs received
+    # in the expected form below. The 'tags' hash will then be deprecated.
+    # Rework this method when that happens.
+    if document["links"] && document["links"]["parent"]
+      api_params.merge!({"links" => document["links"]})
+    end
+
+    api_params
   end
 
 private

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -1,5 +1,6 @@
 require "gds_api/email_alert_api"
 require "models/lock_handler"
+require "models/email_alert_template"
 
 class EmailAlert
   def initialize(document, logger)
@@ -16,11 +17,10 @@ class EmailAlert
   end
 
   def format_for_email_api
-    {
     api_params = {
       "subject" => document["title"],
-      "body" => format_email_body,
-      "tags" => strip_empty_arrays(document["details"]["tags"]),
+      "body"    => EmailAlertTemplate.new(document).message_body,
+      "tags"    => strip_empty_arrays(document["details"]["tags"]),
     }
 
     # FIXME: this conditional check on links should be considered temporary.
@@ -46,33 +46,7 @@ private
     GdsApi::EmailAlertApi.new(Plek.find("email-alert-api"))
   end
 
-  def format_email_body
-    %Q( <div class="rss_item" data-message-id="#{document_identifier_hash}" style="margin-bottom: 2em;">
-          <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
-            <a href="#{make_url_from_document_base_path}" style="font-weight: bold; ">#{document["title"]}</a>
-          </div>
-          #{formatted_public_updated_at}
-          #{document["details"]["change_note"]}
-          <br />
-          <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{document["description"]}</div>
-        </div> )
-  end
-
-  def make_url_from_document_base_path
-    Plek.new.website_root + document["base_path"]
-  end
-
   def strip_empty_arrays(tag_hash)
-    tag_hash.reject {|_, tags|
-      tags.empty?
-    }
-  end
-
-  def formatted_public_updated_at
-    DateTime.parse(document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
-  end
-
-  def document_identifier_hash
-    MessageIdentifier.new(document["title"], document["public_updated_at"]).create
+    tag_hash.reject { |_, tags| tags.empty? }
   end
 end

--- a/email_alert_service/models/email_alert_template.rb
+++ b/email_alert_service/models/email_alert_template.rb
@@ -1,0 +1,33 @@
+class EmailAlertTemplate
+  def initialize(document)
+    @document = document
+  end
+
+  def message_body
+    %Q(
+      <div class="rss_item" data-message-id="#{document_identifier_hash}" style="margin-bottom: 2em;">
+        <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
+          <a href="#{make_url_from_document_base_path}" style="font-weight: bold; ">#{@document["title"]}</a>
+        </div>
+        #{formatted_public_updated_at}
+        #{@document["details"]["change_note"]}
+        <br />
+        <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{@document["description"]}</div>
+      </div>
+    )
+  end
+
+private
+
+  def make_url_from_document_base_path
+    Plek.new.website_root + @document["base_path"]
+  end
+
+  def formatted_public_updated_at
+    DateTime.parse(@document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
+  end
+
+  def document_identifier_hash
+    MessageIdentifier.new(@document["title"], @document["public_updated_at"]).create
+  end
+end


### PR DESCRIPTION
Update the email alert model to include a links hash containing a content
ID, if one is present in the payload received from a client app.

This enables support for email alert notifications triggered by either
tags or links. This is an intermediate state as we migrate to using
links/content IDs only.

Includes a second refactoring commit.

Trello: https://trello.com/c/ZD65QUBN/326-email-alerts-based-on-links-hash