### PR TITLE
Drop check on 'links' => 'parent' in email alert model

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -17,21 +17,12 @@ class EmailAlert
   end
 
   def format_for_email_api
-    api_params = {
+    {
       "subject" => document["title"],
       "body"    => EmailAlertTemplate.new(document).message_body,
       "tags"    => strip_empty_arrays(document["details"]["tags"]),
+      "links"   => document["links"],
     }
-
-    # FIXME: this conditional check on links should be considered temporary.
-    # Eventually we want all email alerts to be triggered via content IDs received
-    # in the expected form below. The 'tags' hash will then be deprecated.
-    # Rework this method when that happens.
-    if document["links"] && document["links"]["parent"]
-      api_params.merge!({"links" => document["links"]})
-    end
-
-    api_params
   end
 
 private

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe EmailAlert do
           "some_other_missing_tags" => [],
         }
       },
+      "links" => {},
       "public_updated_at" => updated_now.iso8601,
     }
   end
@@ -65,6 +66,7 @@ RSpec.describe EmailAlert do
           "browse_pages" => ["tax/vat"],
           "topics" => ["oil-and-gas/licensing"]
         },
+        "links" => {},
       })
     end
 


### PR DESCRIPTION
Rather than check for the presence of this key, simply merge the links
of the incoming document in. The email-alert-api will handle matching
and sending alerts to the appropriate subscriber lists.