### PR TITLE
Change supported tags for email alerts

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -51,7 +51,7 @@ private
 
   def email_alerts_supported?(document)
     document_tags = document.fetch("details", {}).fetch("tags", {})
-    supported_tag_names = ["topics", "policy"]
+    supported_tag_names = ["topics", "policies"]
 
     supported_tag_names.any? do |tag_name|
       !(document_tags[tag_name].nil? || document_tags[tag_name].empty?)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe MessageProcessor do
         "change_note": "this doc has been changed",
         "tags": {
           "browse_pages": [],
-          "policy": ["some-policy-slug"]
+          "policies": ["some-policy-slug"]
         }
       }
     }


### PR DESCRIPTION
Currently, MessageProcessor only supports email alerts for documents
that are tagged with either 'topics' or 'policy'. The latter is
incorrect - content items tagged to policies use the tag name
'policies' (plural). This change is intended to fix the behaviour
of policy email alerts in production.