### PR TITLE
Update logging info when sending email alert

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -9,8 +9,7 @@ class EmailAlert
   end
 
   def trigger
-    logger.info "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}"
-
+    logger.info "Received major change notification for #{document["title"]}, with details #{document["details"]}"
     lock_handler.with_lock_unless_done do
       email_api_client.send_alert(format_for_email_api)
     end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe EmailAlert do
       email_alert.trigger
 
       expect(logger).to have_received(:info).with(
-        "Received major change notification for #{document["title"]}, with topics #{document["details"]["tags"]["topics"]}"
+        "Received major change notification for #{document["title"]}, with details #{document["details"]}"
       )
     end
 


### PR DESCRIPTION
Previously the log string in question made explicit reference to a document's
topic tags. A document may also be tagged to policies. By simply printing the
entire details hash, better (more complete) info is provided about the document's
tagging.