### PR TITLE
Policy Change email alerts to have link to policy

### DIFF
--- a/email_alert_service/models/email_alert_template.rb
+++ b/email_alert_service/models/email_alert_template.rb
@@ -1,3 +1,5 @@
+require  File.dirname(__FILE__) + '/../../lib/services.rb'
+
 class EmailAlertTemplate
   def initialize(document)
     @document = document
@@ -20,7 +22,9 @@ class EmailAlertTemplate
 private
 
   def make_url_from_document_base_path
-    Plek.new.website_root + @document["base_path"]
+    base_path = @document["base_path"]
+    content_item = Services.content_store.content_item(base_path)
+    link = content_item['links']['parent'].first['web_url']
   end
 
   def formatted_public_updated_at

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -x
 export DISPLAY=:99
-export GOVUK_APP_DOMAIN=test.gov.uk
 export REPO_NAME="alphagov/email-alert-service"
 env
 

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,7 @@
+require 'gds_api/content_store'
+
+module Services
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.new.find('content-store'))
+  end
+end

--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Receiving major change notifications", type: :integration do
   include LockHandlerTestHelpers
+  include ContentItemHelpers
 
   let(:well_formed_document) {
     {
@@ -21,8 +22,11 @@ RSpec.describe "Receiving major change notifications", type: :integration do
 
   let(:malformed_json) { '{23o*&£}' }
   let(:invalid_document) { '{"houses": "are for living in"}' }
+  let(:content_store_url)   { 'https://content-store.test.gov.uk/contentpath/to-doc' }
+  let(:web_url)             { 'https://www.gov.uk/content/policies/2012-olympic-and-paralympic-legacy' }
 
   around :each do |example|
+    system('GOVUK_ENV=test bin/delete_queue')
     start_listener
     example.run
     stop_listener
@@ -49,6 +53,7 @@ RSpec.describe "Receiving major change notifications", type: :integration do
   it "acknowledges the message for documents experiencing major changes" do
     expect_any_instance_of(MessageProcessor).to receive(:acknowledge).and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
+    stub_call_to_content_store(content_store_url, web_url)
 
     send_message(well_formed_document, routing_key: "policy.major")
 
@@ -68,6 +73,8 @@ RSpec.describe "Receiving major change notifications", type: :integration do
   it "sends an email alert for documents experiencing major changes" do
     expect_any_instance_of(MessageProcessor).to receive(:acknowledge).and_call_original
     expect_any_instance_of(GdsApi::EmailAlertApi).to receive(:send_alert)
+    
+    stub_call_to_content_store(content_store_url, web_url)
 
     send_message(well_formed_document, routing_key: "policy.major")
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe EmailAlert do
   include LockHandlerTestHelpers
+  include ContentItemHelpers
 
   let(:document) do
     {
@@ -37,6 +38,7 @@ RSpec.describe EmailAlert do
 
   describe "#trigger" do
     it "logs receiving a major change notification for a document" do
+      stub_call_to_content_store("https://content-store.test.gov.uk/content/foo", "my_url")
       email_alert.trigger
 
       expect(logger).to have_received(:info).with(
@@ -45,6 +47,7 @@ RSpec.describe EmailAlert do
     end
 
     it "sends an alert to the Email Alert API" do
+      stub_call_to_content_store("https://content-store.test.gov.uk/content/foo", "my_url")
       email_alert.trigger
 
       expect(alert_api).to have_received(:send_alert)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 ENV["GOVUK_ENV"] = "test"
+ENV['GOVUK_APP_DOMAIN']='test.gov.uk'
 
 require "webmock/rspec"
 require "gds_api/test_helpers/email_alert_api"

--- a/spec/support/content_item_helper.rb
+++ b/spec/support/content_item_helper.rb
@@ -1,0 +1,61 @@
+module ContentItemHelpers
+
+  def stub_call_to_content_store(content_store_url, web_url)
+    stub_request(:get, content_store_url).to_return(body: content_item('my_url'))
+  end
+
+  def content_item(web_url)
+    {
+      "base_path" => "/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+      "content_id"=>"404e4ebc-d413-44d6-b157-b70c118397d3",
+      "title"=>"2012 Olympic and Paralympic legacy",
+      "description"=>"",
+      "format"=>"email_alert_signup",
+      "need_ids"=>[],
+      "locale"=>"en",
+      "updated_at"=>"2015-11-05T13:06:52.413Z",
+      "public_updated_at"=>"2015-05-26T15:15:26.742+00:00",
+      "details"=>{
+        "breadcrumbs"=> [
+          {
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "link"=>"/government/policies/2012-olympic-and-paralympic-legacy"
+          }
+        ],
+        "summary"=>"\n      You'll get an email each time a document about\n      this policy is published or updated.\n    ",
+        "tags"=>{
+          "policy"=>[
+            "2012-olympic-and-paralympic-legacy"
+          ]
+        },
+        "govdelivery_title"=>"2012 Olympic and Paralympic legacy policy"
+      },
+      "phase"=>"live",
+      "analytics_identifier"=>nil,
+      "links"=>{
+        "parent"=>[
+          {
+            "content_id"=>"5d37821b-7631-11e4-a3cb-005056011aef",
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "base_path"=>"/government/policies/2012-olympic-and-paralympic-legacy",
+            "description"=>"",
+            "api_url"=>"https://www.gov.uk/api/content/government/policies/2012-olympic-and-paralympic-legacy",
+            "web_url"=> web_url,
+            "locale"=>"en"
+          }
+        ],
+        "available_translations"=>[
+          {
+            "content_id"=>"404e4ebc-d413-44d6-b157-b70c118397d3",
+            "title"=>"2012 Olympic and Paralympic legacy",
+            "base_path"=>"/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "description"=>"",
+            "api_url"=>"https://www.gov.uk/api/content/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "web_url"=>"https://www.gov.uk/government/policies/2012-olympic-and-paralympic-legacy/email-signup",
+            "locale"=>"en"
+          }
+        ]
+      }
+    }.to_json
+  end
+end


### PR DESCRIPTION
Currently, the emails sent out to subscribers to policy change alerts have a link
to the policy alert signup page, not to the policy itself.  This change fixes that bug.

https://trello.com/c/JExeIwcb