### PR TITLE
Check links hash for tags when determining whether or not to send email

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -19,8 +19,8 @@ class EmailAlert
     {
       "subject" => document["title"],
       "body"    => EmailAlertTemplate.new(document).message_body,
-      "tags"    => strip_empty_arrays(document["details"]["tags"]),
-      "links"   => document["links"],
+      "tags"    => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
+      "links"   => strip_empty_arrays(document.fetch("links", {})),
     }
   end
 

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -51,10 +51,14 @@ private
 
   def email_alerts_supported?(document)
     document_tags = document.fetch("details", {}).fetch("tags", {})
-    supported_tag_names = ["topics", "policies"]
+    document_links = document.fetch("links", {})
+    contains_supported_tag?(document_links) || contains_supported_tag?(document_tags)
+  end
 
+  def contains_supported_tag?(tags_hash)
+    supported_tag_names = ["topics", "policies"]
     supported_tag_names.any? do |tag_name|
-      !(document_tags[tag_name].nil? || document_tags[tag_name].empty?)
+      tags_hash[tag_name] && tags_hash[tag_name].any?
     end
   end
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe EmailAlert do
       })
     end
 
-    context "a parent link is present in the document" do
-      before { document.merge!( { "links" => { "parent" => ["uuid-888"] } } ) }
+    context "a link is present in the document" do
+      before { document.merge!( { "links" => { "topics" => ["uuid-888"] } } ) }
 
       it "formats the message to include the parent link" do
         expect(email_alert.format_for_email_api).to eq({
@@ -82,8 +82,26 @@ RSpec.describe EmailAlert do
             "topics"=>["oil-and-gas/licensing"]
           },
           "links" => {
-            "parent" => ["uuid-888"]
+            "topics" => ["uuid-888"]
           },
+        })
+      end
+    end
+
+    context "blank tags are present" do
+      before do
+        document.merge!("links" => { "topics" => [] })
+        document["details"]["tags"].merge!("topics" => [])
+      end
+
+      it "strips these out" do
+        expect(email_alert.format_for_email_api).to eq({
+          "subject" => "Example title",
+          "body" => "This is an email.",
+          "tags" => {
+            "browse_pages"=>["tax/vat"],
+          },
+          "links" => {}
         })
       end
     end


### PR DESCRIPTION
This checks the incoming document's links hash for the presence of topic
or policy tags. It also cleans up some of the tests related to message
processing and the email alert api payload.

In message_processor_spec.rb in particular, this commit tries to make
the tests easier to follow by mutating the test data in each test case
(rather than setting up multiple, complete test documents at the top of
the spec). It preserves (and builds upon) the variety of scenarios the
processor is supposed to handle.

Trello: https://trello.com/c/gdrGvo9n