### PR TITLE
Add Rake to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
+gem "rake"
 gem "airbrake", "4.1.0"
 gem 'bunny', "~> 1.5.0"
 gem "gds-api-adapters", "20.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
+    rake (10.5.0)
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
@@ -83,9 +84,13 @@ DEPENDENCIES
   gds-api-adapters (= 20.1.1)
   plek (= 1.9.0)
   pry-byebug
+  rake
   redis (= 3.1.0)
   redis-namespace (= 1.5.1)
   rspec-core (= 3.1.4)
   rspec-expectations (= 3.1.1)
   rspec-mocks (= 3.1.1)
   webmock (= 1.19.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
This is needed in production, but is not currently listed in the Gemfile.

This will fix problems with deploying this app in integration:

https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/1921/console
