### PR TITLE
Allow documents with service manual topics to trigger emails

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -18,9 +18,10 @@ class EmailAlert
   def format_for_email_api
     {
       "subject" => document["title"],
-      "body"    => EmailAlertTemplate.new(document).message_body,
-      "tags"    => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
-      "links"   => strip_empty_arrays(document.fetch("links", {})),
+      "body" => EmailAlertTemplate.new(document).message_body,
+      "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
+      "links" => strip_empty_arrays(document.fetch("links", {})),
+      "document_type" => document["document_type"]
     }
   end
 

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -52,12 +52,13 @@ private
   def email_alerts_supported?(document)
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
-    contains_supported_tag?(document_links) || contains_supported_tag?(document_tags)
+    contains_supported_attribute?(document_links) \
+      || contains_supported_attribute?(document_tags)
   end
 
-  def contains_supported_tag?(tags_hash)
-    supported_tag_names = ["topics", "policies"]
-    supported_tag_names.any? do |tag_name|
+  def contains_supported_attribute?(tags_hash)
+    supported_attributes = ["topics", "policies", "service_manual_topics"]
+    supported_attributes.any? do |tag_name|
       tags_hash[tag_name] && tags_hash[tag_name].any?
     end
   end

--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "Receiving major change notifications", type: :integration do
           "browse_pages" => [],
           "topics" => ["example topic"]
         }
-      }
+      },
+      "document_type" => "example_document"
     }.to_json
   }
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe EmailAlert do
       },
       "links" => {},
       "public_updated_at" => updated_now.iso8601,
+      "document_type" => "example_document"
     }
   end
 
@@ -67,6 +68,7 @@ RSpec.describe EmailAlert do
           "topics" => ["oil-and-gas/licensing"]
         },
         "links" => {},
+        "document_type" => "example_document"
       })
     end
 
@@ -84,6 +86,7 @@ RSpec.describe EmailAlert do
           "links" => {
             "topics" => ["uuid-888"]
           },
+          "document_type" => "example_document"
         })
       end
     end
@@ -101,7 +104,8 @@ RSpec.describe EmailAlert do
           "tags" => {
             "browse_pages"=>["tax/vat"],
           },
-          "links" => {}
+          "links" => {},
+          "document_type" => "example_document"
         })
       end
     end


### PR DESCRIPTION
We're building email alerting into the service manual.

1) We need documents with a link to `service_manual_topics` to be sent to the email alert api so that they can be matched against possible subscriber lists.

I've also renamed the method from `contains_supported_tag?` to `contains_supported_attribute?` because the method is used for checking both tags and links.

2) The email alert api allows for matching on document type, but the email alert service does not currently send the document type. The only way the document_type matcher can currently be used is by hitting it directly (as travel-advice-publisher does).

This changes the service to always send the document type to the email alert api. The document type should be irrelevant unless a subscriber list is set to match against it, so this should have no impact on existing subscriptions.