### PR TITLE
Use expanded links from publishing API [DO NOT MERGE]

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -20,7 +20,9 @@ class EmailAlert
       "subject" => document["title"],
       "body" => EmailAlertTemplate.new(document).message_body,
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
-      "links" => strip_empty_arrays(document.fetch("links", {})),
+      "links" => strip_empty_arrays(
+        as_lists_of_content_ids(document.fetch("expanded_links", {}))
+      ),
       "document_type" => document["document_type"]
     }
   end
@@ -31,6 +33,14 @@ private
 
   def lock_handler
     LockHandler.new(document.fetch("title"), document.fetch("public_updated_at"))
+  end
+
+  def as_lists_of_content_ids(expanded_links)
+    expanded_links.each_with_object({}) do |(linkset_name, linkset), output|
+      output[linkset_name] = linkset.map do |link|
+        link["content_id"]
+      end
+    end
   end
 
   def email_api_client

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -51,7 +51,7 @@ private
 
   def email_alerts_supported?(document)
     document_tags = document.fetch("details", {}).fetch("tags", {})
-    document_links = document.fetch("links", {})
+    document_links = document.fetch("expanded_links", {})
     contains_supported_attribute?(document_links) \
       || contains_supported_attribute?(document_tags)
   end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EmailAlert do
           "some_other_missing_tags" => [],
         }
       },
-      "links" => {},
+      "expanded_links" => {},
       "public_updated_at" => updated_now.iso8601,
       "document_type" => "example_document"
     }
@@ -73,9 +73,33 @@ RSpec.describe EmailAlert do
     end
 
     context "a link is present in the document" do
-      before { document.merge!( { "links" => { "topics" => ["uuid-888"] } } ) }
+      before do
+        document.merge!(
+          {
+            "expanded_links" => {
+              "topics" => [
+                {
+                  "analytics_identifier" => "12345",
+                  "api_url" => "https://www.publishing.service.gov.uk/api/content/example/topic",
+                  "base_path" => "/example/topic",
+                  "content_id" => "uuid-888",
+                  "description" => nil,
+                  "document_type" => "example",
+                  "locale" => "en",
+                  "public_updated_at" => "2016-02-07T20:08:15Z",
+                  "schema_name" => "example",
+                  "title" => "Example linked content",
+                  "web_url" => "https://www.gov.uk/example/topic",
+                  "details" => {},
+                  "links" => {}
+                }
+              ]
+            }
+          }
+        )
+      end
 
-      it "formats the message to include the parent link" do
+      it "includes a list of just the link content ids" do
         expect(email_alert.format_for_email_api).to eq({
           "subject" => "Example title",
           "body" => "This is an email.",
@@ -93,7 +117,7 @@ RSpec.describe EmailAlert do
 
     context "blank tags are present" do
       before do
-        document.merge!("links" => { "topics" => [] })
+        document.merge!("expanded_links" => { "topics" => [] })
         document["details"]["tags"].merge!("topics" => [])
       end
 

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -22,8 +22,24 @@ RSpec.describe MessageProcessor do
           "topics" => ["example topic"]
         }
       },
-      "links" => {
-        "topics" => ["example-topic-uuid"]
+      "expanded_links" => {
+        "topics" => [
+          {
+            "analytics_identifier" => "12345",
+            "api_url" => "https://www.publishing.service.gov.uk/api/content/example/topic",
+            "base_path" => "/example/topic",
+            "content_id" => "example-topic-uuid",
+            "description" => nil,
+            "document_type" => "example",
+            "locale" => "en",
+            "public_updated_at" => "2016-02-07T20:08:15Z",
+            "schema_name" => "example",
+            "title" => "Example linked content",
+            "web_url" => "https://www.gov.uk/example/topic",
+            "details" => {},
+            "links" => {}
+          }
+        ]
       }
     }
   }
@@ -59,7 +75,7 @@ RSpec.describe MessageProcessor do
     context "document tagged with a policy" do
       before do
         good_document["details"]["tags"] = { "policies" => ["example policy"] }
-        good_document["links"] = { "policies" => ["example-policy-uuid"] }
+        good_document["expanded_links"] = { "policies" => ["example-policy-uuid"] }
       end
 
       it "acknowledges and triggers the email" do
@@ -85,7 +101,7 @@ RSpec.describe MessageProcessor do
 
     context "document with no tags in its links hash" do
       before do
-        good_document["links"].delete("topics")
+        good_document["expanded_links"].delete("topics")
       end
 
       it "still acknowledges and triggers the email" do
@@ -99,7 +115,7 @@ RSpec.describe MessageProcessor do
     context "document with empty tags" do
       before do
         good_document["details"]["tags"] = { "topics" => [] }
-        good_document["links"] = { "topics" => [] }
+        good_document["expanded_links"] = { "topics" => [] }
       end
 
       it "acknowledges but doesn't trigger the email" do
@@ -112,7 +128,7 @@ RSpec.describe MessageProcessor do
 
     context "document with missing tag fields" do
       before do
-        good_document["links"].delete("topics")
+        good_document["expanded_links"].delete("topics")
         good_document["details"].delete("tags")
       end
 
@@ -136,7 +152,7 @@ RSpec.describe MessageProcessor do
     end
 
     context "missing links hash" do
-      before { good_document.delete("links") }
+      before { good_document.delete("expanded_links") }
 
       it "still acknowledges and triggers the email" do
         processor.process(good_document.to_json, properties, delivery_info)
@@ -147,7 +163,10 @@ RSpec.describe MessageProcessor do
     end
 
     context "no details hash, no links hash" do
-      before { good_document.delete("links"); good_document.delete("details") }
+      before do
+        good_document.delete("expanded_links")
+        good_document.delete("details")
+      end
 
       it "acknowledges but doesn't trigger the email" do
         processor.process(good_document.to_json, properties, delivery_info)


### PR DESCRIPTION
The publishing api no longer sends the non-expanded `links` to downstream workers – only `expanded_links`.

Update the message_processor to inspect the contents of  the expanded_links hash when considering whether a message needs to be sent to the email alert api.

The Email Alert API expects the `links` in its payload to be a hash of linksets containing just lists of content ids so we also need to contract them back down again.