### PR TITLE
Send all service manual guides to email alert api

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -52,8 +52,10 @@ private
   def email_alerts_supported?(document)
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
+    document_type = document.fetch("document_type")
     contains_supported_attribute?(document_links) \
-      || contains_supported_attribute?(document_tags)
+      || contains_supported_attribute?(document_tags) \
+      || whitelisted_document_type?(document_type)
   end
 
   def contains_supported_attribute?(tags_hash)
@@ -61,6 +63,10 @@ private
     supported_attributes.any? do |tag_name|
       tags_hash[tag_name] && tags_hash[tag_name].any?
     end
+  end
+
+  def whitelisted_document_type?(document_type)
+    document_type == "service_manual_guide"
   end
 
   def is_english?(document)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe MessageProcessor do
     {
       "base_path" => "path/to-doc",
       "title" => "Example title",
+      "document_type" => "example",
       "description" => "example description",
       "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
       "details" => {
@@ -137,6 +138,21 @@ RSpec.describe MessageProcessor do
 
     context "missing links hash" do
       before { good_document.delete("links") }
+
+      it "still acknowledges and triggers the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_triggered
+        message_acknowledged
+      end
+    end
+
+    context "no links or tags but of whitelisted document type" do
+      before do
+        good_document["details"] = {}
+        good_document["links"] = { "parent" => ["parent-topic-uuid"] }
+        good_document["document_type"] = "service_manual_guide"
+      end
 
       it "still acknowledges and triggers the email" do
         processor.process(good_document.to_json, properties, delivery_info)


### PR DESCRIPTION
We want users to be able to subscribe to changes to the service manual standard points. Points are just guides where the service standard is the parent. We don't want to send all documents with parents to the email alert api. Instead we send all the guides and let the email alert api work it out.