### PR TITLE
Robustly detect missing attributes

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -75,15 +75,19 @@ private
   end
 
   def is_english?(document)
-    document.fetch("locale", "en") == "en"
+    # a missing locale is assumed to be English, but a "null" locale
+    # is not
+    return true unless document.key?("locale")
+
+    document["locale"] == "en"
   end
 
   def has_title?(document)
-    document.fetch("title", "") != ""
+    has_non_blank_value_for_key?(document: document, key: "title")
   end
 
   def has_public_updated_at?(document)
-    document.fetch("public_updated_at", "") != ""
+    has_non_blank_value_for_key?(document: document, key: "public_updated_at")
   end
 
   def acknowledge(message)
@@ -92,5 +96,13 @@ private
 
   def discard(delivery_tag)
     channel.reject(delivery_tag, false)
+  end
+
+  private
+  def has_non_blank_value_for_key?(document:, key:)
+    # a key can be present but the value is nil, so fetch won't
+    # protect us here
+    return false unless document.key?(key)
+    (document[key] || "") != ""
   end
 end

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -30,6 +30,11 @@ private
       return
     end
 
+    unless has_public_updated_at?(document)
+      @logger.info "not triggering email alert for document with no public_updated_at: #{document}"
+      return
+    end
+
     unless is_english?(document)
       @logger.info "not triggering email alert for non-english document #{document["title"]}: locale #{document["locale"]}"
       return
@@ -75,6 +80,10 @@ private
 
   def has_title?(document)
     document.fetch("title", "") != ""
+  end
+
+  def has_public_updated_at?(document)
+    document.fetch("public_updated_at", "") != ""
   end
 
   def acknowledge(message)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -199,8 +199,6 @@ RSpec.describe MessageProcessor do
       before { good_document["locale"] = "fr" }
 
       it "acknowledges but doesn't trigger the email" do
-        properties = double(:properties, content_type: "application/x-heartbeat")
-
         processor.process(good_document.to_json, properties, delivery_info)
 
         email_was_not_triggered
@@ -212,8 +210,6 @@ RSpec.describe MessageProcessor do
       before { good_document.delete("title") }
 
       it "acknowledges but doesn't trigger the email" do
-        properties = double(:properties, content_type: "application/x-heartbeat")
-
         processor.process(good_document.to_json, properties, delivery_info)
 
         email_was_not_triggered
@@ -225,8 +221,6 @@ RSpec.describe MessageProcessor do
       before { good_document.delete("public_updated_at") }
 
       it "acknowledges but doesn't trigger the email" do
-        properties = double(:properties, content_type: "application/x-heartbeat")
-
         processor.process(good_document.to_json, properties, delivery_info)
 
         email_was_not_triggered

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -206,6 +206,17 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "document has blank locale" do
+      before { good_document["locale"] = nil }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "document has no title" do
       before { good_document.delete("title") }
 
@@ -217,8 +228,30 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "document has blank title" do
+      before { good_document["title"] = nil }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "document has no public_updated_at" do
       before { good_document.delete("public_updated_at") }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "document has blank public_updated_at" do
+      before { good_document["public_updated_at"] = nil }
 
       it "acknowledges but doesn't trigger the email" do
         processor.process(good_document.to_json, properties, delivery_info)


### PR DESCRIPTION
To fix https://errbit.publishing.service.gov.uk/apps/545387cd0da115367c00f0c6/problems/584fd0a36578630e38c70700

See the commit notes for the story, but the tl;dr is that `Hash#fetch` doesn't protect us against keys with `nil` values.

/cc @tijmenb, @alexmuller, @jennyd 