### PR TITLE
[DO NOT MERGE] Spike: pass taxon data to EmailAlertApi for matching

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -20,12 +20,29 @@ class EmailAlert
       "subject" => document["title"],
       "body" => EmailAlertTemplate.new(document).message_body,
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
-      "links" => strip_empty_arrays(document.fetch("links", {})),
+      "links" => strip_empty_arrays(document.fetch("links", {}).merge('taxons_tree' => taxon_tree)),
       "document_type" => document["document_type"]
     }
   end
 
 private
+
+  def taxon_tree
+    node = document.fetch("expanded_links", {}).fetch('taxons', []).first
+    return [] unless node
+    [node['content_id']] + children_taxons(node)
+  end
+
+  def children_taxons(node)
+    # binding.pry
+    links_node = node.fetch("links", {})
+    if links_node.key?("parent_taxons")
+      parent_node = links_node["parent_taxons"].first
+      [parent_node['content_id']] + children_taxons(parent_node)
+    else
+      []
+    end
+  end
 
   attr_reader :document, :logger
 

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -28,17 +28,19 @@ class EmailAlert
 private
 
   def taxon_tree
-    node = document.fetch("expanded_links", {}).fetch('taxons', []).first
-    return [] unless node
-    [node['content_id']] + children_taxons(node)
+    nodes = document.fetch("expanded_links", {}).fetch('taxons', [])
+    nodes.flat_map do |node|
+      [node['content_id']] + children_taxons(node)
+    end
   end
 
   def children_taxons(node)
     # binding.pry
     links_node = node.fetch("links", {})
     if links_node.key?("parent_taxons")
-      parent_node = links_node["parent_taxons"].first
-      [parent_node['content_id']] + children_taxons(parent_node)
+      links_node["parent_taxons"].flat_map do |parent_node|
+        [parent_node['content_id']] + children_taxons(parent_node)
+      end
     else
       []
     end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -155,5 +155,54 @@ RSpec.describe EmailAlert do
         })
       end
     end
+
+    context "mutliple taxons are present in the expanded_links data" do
+      before do
+        document.merge!(
+          "expanded_links" => {
+            "taxons" => [
+              {
+                "content_id" => "b67afac3-0bfc-4e44-9893-951be4d05e4c",
+                "links" => {
+                  "parent_taxons" => [
+                    {
+                      "content_id" => "db605204-0f03-441b-837f-16613c6b3f8f",
+                      "links" => {
+                        "parent_taxons" => [
+                          {
+                            "content_id" => "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                            "links" => {}
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "content_id" => "1111111-0f03-441b-837f-16613c6b3f8f",
+                      "links" => {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        )
+      end
+
+      it "populates links with 'taxon' and 'taxon_tree' data" do
+        expect(email_alert.format_for_email_api).to eq({
+          "subject" => "Example title",
+          "body" => "This is an email.",
+          "tags" => {
+            "browse_pages"=>["tax/vat"],
+            "topics"=>["oil-and-gas/licensing"]
+          },
+          "links" => {
+            "taxons_tree" => ["b67afac3-0bfc-4e44-9893-951be4d05e4c", "db605204-0f03-441b-837f-16613c6b3f8f", "c58fdadd-7743-46d6-9629-90bb3ccc4ef0", "1111111-0f03-441b-837f-16613c6b3f8f"]
+          },
+          "document_type" => "example_document"
+        })
+      end
+    end
+
   end
 end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -109,5 +109,51 @@ RSpec.describe EmailAlert do
         })
       end
     end
+
+    context "taxons are present in the links and expanded_links data" do
+      before do
+        document.merge!("links" => { "taxons" => [ "b67afac3-0bfc-4e44-9893-951be4d05e4c" ] })
+        document.merge!(
+          "expanded_links" => {
+            "taxons" => [
+              {
+                "content_id" => "b67afac3-0bfc-4e44-9893-951be4d05e4c",
+                "links" => {
+                  "parent_taxons" => [
+                    {
+                      "content_id" => "db605204-0f03-441b-837f-16613c6b3f8f",
+                      "links" => {
+                        "parent_taxons" => [
+                          {
+                            "content_id" => "c58fdadd-7743-46d6-9629-90bb3ccc4ef0",
+                            "links" => {}
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        )
+      end
+
+      it "populates links with 'taxon' and 'taxon_tree' data" do
+        expect(email_alert.format_for_email_api).to eq({
+          "subject" => "Example title",
+          "body" => "This is an email.",
+          "tags" => {
+            "browse_pages"=>["tax/vat"],
+            "topics"=>["oil-and-gas/licensing"]
+          },
+          "links" => {
+            "taxons" => ["b67afac3-0bfc-4e44-9893-951be4d05e4c"],
+            "taxons_tree" => ["b67afac3-0bfc-4e44-9893-951be4d05e4c", "db605204-0f03-441b-837f-16613c6b3f8f", "c58fdadd-7743-46d6-9629-90bb3ccc4ef0"]
+          },
+          "document_type" => "example_document"
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
Trade Taxons (The single parent taxon) and taxons_tree
(all ancestor taxons) as two different concepts.

This way teh matching in EmailAlertApi does not need
any additional code changes, it relies instaed on the
matchers beging setup with teh correct key: taxons or taxons_tree

https://trello.com/c/9e0nJkrQ/109-spike-how-do-we-support-the-new-taxonomy