### PR TITLE
Add logging parameters for EmailAlertApi

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -21,7 +21,10 @@ class EmailAlert
       "body" => EmailAlertTemplate.new(document).message_body,
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
       "links" => strip_empty_arrays(document.fetch("links", {})),
-      "document_type" => document["document_type"]
+      "document_type" => document["document_type"],
+      "content_id" => document["content_id"],
+      "public_updated_at" => document["public_updated_at"],
+      "publishing_app" => document["publishing_app"],
     }
   end
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -2,10 +2,12 @@ require "spec_helper"
 
 RSpec.describe EmailAlert do
   include LockHandlerTestHelpers
-
+  let(:content_id) { SecureRandom.uuid }
+  let(:public_updated_at) { updated_now.iso8601 }
   let(:document) do
     {
       "base_path" => "/foo",
+      "content_id" => content_id,
       "title" => "Example title",
       "details" => {
         "tags" => {
@@ -15,8 +17,9 @@ RSpec.describe EmailAlert do
         }
       },
       "links" => {},
-      "public_updated_at" => updated_now.iso8601,
-      "document_type" => "example_document"
+      "public_updated_at" => public_updated_at,
+      "document_type" => "example_document",
+      "publishing_app" => "Whitehall"
     }
   end
 
@@ -63,6 +66,9 @@ RSpec.describe EmailAlert do
       expect(email_alert.format_for_email_api).to eq({
         "subject" => "Example title",
         "body" => "This is an email.",
+        "content_id" => content_id,
+        "public_updated_at" => public_updated_at,
+        "publishing_app" => "Whitehall",
         "tags" => {
           "browse_pages" => ["tax/vat"],
           "topics" => ["oil-and-gas/licensing"]
@@ -79,6 +85,9 @@ RSpec.describe EmailAlert do
         expect(email_alert.format_for_email_api).to eq({
           "subject" => "Example title",
           "body" => "This is an email.",
+          "content_id" => content_id,
+          "public_updated_at" => public_updated_at,
+          "publishing_app" => "Whitehall",
           "tags" => {
             "browse_pages"=>["tax/vat"],
             "topics"=>["oil-and-gas/licensing"]
@@ -101,6 +110,9 @@ RSpec.describe EmailAlert do
         expect(email_alert.format_for_email_api).to eq({
           "subject" => "Example title",
           "body" => "This is an email.",
+          "content_id" => content_id,
+          "public_updated_at" => public_updated_at,
+          "publishing_app" => "Whitehall",
           "tags" => {
             "browse_pages"=>["tax/vat"],
           },


### PR DESCRIPTION
Added content_id, publishing app and public_updated_at fields so that
EmailAlertApi can use them in the logs.
This will allow greater visibility of how the matching works and
mean we can compare against what is matched in GovUkDelivery in preparation
for the migration.
https://trello.com/c/b9ZonGXn/121-logging