### PR TITLE
Pass supertype fields to email alert API

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -23,6 +23,8 @@ class EmailAlert
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
       "links" => document_links,
       "document_type" => document["document_type"],
+      "email_document_supertype" => document["email_document_supertype"],
+      "government_document_supertype" => document["government_document_supertype"],
       "content_id" => document["content_id"],
       "public_updated_at" => document["public_updated_at"],
       "publishing_app" => document["publishing_app"],

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe EmailAlert do
       "links" => {},
       "public_updated_at" => public_updated_at,
       "document_type" => "example_document",
+      "email_document_supertype" => "publications",
+      "government_document_supertype" => "example_supertype",
       "publishing_app" => "Whitehall",
       "govuk_request_id" => govuk_request_id,
     }
@@ -79,7 +81,9 @@ RSpec.describe EmailAlert do
           "topics" => ["oil-and-gas/licensing"]
         },
         "links" => {},
-        "document_type" => "example_document"
+        "document_type" => "example_document",
+        "email_document_supertype" => "publications",
+        "government_document_supertype" => "example_supertype",
       })
     end
 
@@ -100,7 +104,9 @@ RSpec.describe EmailAlert do
           "links" => {
             "topics" => ["uuid-888"]
           },
-          "document_type" => "example_document"
+          "document_type" => "example_document",
+          "email_document_supertype" => "publications",
+          "government_document_supertype" => "example_supertype",
         })
       end
     end
@@ -122,7 +128,9 @@ RSpec.describe EmailAlert do
             "browse_pages"=>["tax/vat"],
           },
           "links" => {},
-          "document_type" => "example_document"
+          "document_type" => "example_document",
+          "email_document_supertype" => "publications",
+          "government_document_supertype" => "example_supertype",
         })
       end
     end


### PR DESCRIPTION
Pass the new email_document_supertype and
government_document_supertype fields thorugh.

These are required for the govuk delivery migration.

https://trello.com/c/5yVMib2f/124-2-add-support-for-whitehall-topics-in-new-email-stack