### PR TITLE
Use first note from change_history in email body

### DIFF
--- a/email_alert_service/models/email_alert_template.rb
+++ b/email_alert_service/models/email_alert_template.rb
@@ -10,7 +10,7 @@ class EmailAlertTemplate
           <a href="#{make_url_from_document_base_path}" style="font-weight: bold; ">#{@document["title"]}</a>
         </div>
         #{formatted_public_updated_at}
-        #{@document["details"]["change_note"]}
+        #{latest_change_note}
         <br />
         <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{@document["description"]}</div>
       </div>
@@ -25,6 +25,11 @@ private
 
   def formatted_public_updated_at
     DateTime.parse(@document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
+  end
+
+  def latest_change_note
+    change_note = @document["details"]["change_history"]&.first
+    change_note["note"] if change_note
   end
 
   def document_identifier_hash

--- a/spec/models/email_alert_template_spec.rb
+++ b/spec/models/email_alert_template_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+RSpec.describe EmailAlertTemplate do
+  include LockHandlerTestHelpers
+  let(:content_id) { SecureRandom.uuid }
+  let(:govuk_request_id) { SecureRandom.uuid }
+  let(:public_updated_at) { updated_now.iso8601 }
+  let(:document) do
+    {
+      "base_path" => "/foo",
+      "content_id" => content_id,
+      "title" => "Example title",
+      "details" => {
+        "tags" => {
+          "browse_pages" => ["tax/vat"],
+          "topics" => ["oil-and-gas/licensing"],
+          "some_other_missing_tags" => [],
+        }
+      },
+      "links" => {},
+      "public_updated_at" => public_updated_at,
+      "document_type" => "example_document",
+      "publishing_app" => "Whitehall",
+      "govuk_request_id" => govuk_request_id,
+    }
+  end
+  let(:email_alert_template) { EmailAlertTemplate.new(document) }
+
+  describe "#latest_change_note" do
+    context "no change_history is present in the document" do
+      it "returns nil" do
+        expect(email_alert_template.send(:latest_change_note)).to be_nil
+      end
+    end
+
+    context "change_history is present but empty" do
+      before do
+        document["details"]["change_history"] = []
+      end
+
+      it "returns nil" do
+        expect(email_alert_template.send(:latest_change_note)).to be_nil
+      end
+    end
+
+    context "change_history is present and populated" do
+      before do
+        document["details"]["change_history"] = [
+          {
+            "public_timestamp" => "2017-03-20T16:00:00.000+00:00",
+            "note" => "updated again"
+          },
+          {
+            "public_timestamp" => "2016-02-01T09:30:00.000+00:00",
+            "note" => "First published."
+          }
+        ]
+      end
+
+      it "returns the latest change note" do
+        expect(email_alert_template.send(:latest_change_note)).to eq("updated again")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We would like to include the change note in the email, if we can - it's
helpful for users to have the context of what's changed so they know if it's
relevant to them.

There are a variety of places in content items where change notes can be,
depending on the document type. We were previously only looking in one of
these places, which meant that most emails constructed by email-alert-service
didn't include a change note.

The publishing API tries to store change notes in a consistent format, and has
recently been fixed to ensure that that is done more often [1]. That means
that we should have a "change_history" array in the details hash in the
messages from the queue, in reverse chronological order. This commit switches
to using the first (most recent) change note from there in the email body.

[1]: https://github.com/alphagov/publishing-api/pull/834

https://trello.com/c/oSxpEsnJ/76-add-change-notes-to-emails-from-email-alert-service