### PR TITLE
Support criteria for Whitehall subscriptions

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -55,6 +55,8 @@ private
   end
 
   def email_alerts_supported?(document)
+    return false if blacklisted_publishing_app?(document["publishing_app"])
+
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
     document_type = document.fetch("document_type")
@@ -68,6 +70,13 @@ private
     supported_attributes.any? do |tag_name|
       tags_hash[tag_name] && tags_hash[tag_name].any?
     end
+  end
+
+  def blacklisted_publishing_app?(publishing_app)
+    # These publishing apps make direct calls to email-alert-api to send their
+    # emails, so we need to avoid sending duplicate emails when they come
+    # through on the queue:
+    ['travel-advice-publisher', 'specialist-publisher'].include?(publishing_app)
   end
 
   def whitelisted_document_type?(document_type)

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -100,6 +100,8 @@ private
   end
 
   def whitelisted_document_type?(document_type)
+    # It's possible to subscribe to these without any other filtering, so we
+    # should always let them through
     document_type == "service_manual_guide"
   end
 

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -60,9 +60,11 @@ private
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
     document_type = document.fetch("document_type")
+
     contains_supported_attribute?(document_links) \
       || contains_supported_attribute?(document_tags) \
-      || whitelisted_document_type?(document_type)
+      || whitelisted_document_type?(document_type) \
+      || has_relevant_document_supertype?(document)
   end
 
   def contains_supported_attribute?(tags_hash)
@@ -81,6 +83,21 @@ private
 
   def whitelisted_document_type?(document_type)
     document_type == "service_manual_guide"
+  end
+
+  def has_relevant_document_supertype?(document)
+    def relevant_supertype?(supertype)
+      !(['other', '', nil].include?(supertype))
+    end
+
+    # These supertypes were added to Whitehall content to aid the migration of
+    # Whitehall subscriptions to email-alert-api. We'd like to get to the point
+    # where email subscriptions cover all content on the site rather than
+    # perpetuating the Whitehall/everything else divide, but don't have time to
+    # work through all the ramifications of that while also doing that migration
+    # so are limiting the scope of emails to approximately what Whitehall did.
+    relevant_supertype?(document["government_document_supertype"]) ||
+      relevant_supertype?(document["email_document_supertype"])
   end
 
   def is_english?(document)

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -68,7 +68,25 @@ private
   end
 
   def contains_supported_attribute?(tags_hash)
-    supported_attributes = ["topics", "policies", "service_manual_topics", "taxons"]
+    # These are attributes in links or tags which email subscriptions can be
+    # based on.
+
+    # We also send emails based on links to organisations, but don't include
+    # organisations in this list because that would trigger emails for many
+    # things which aren't appropriate. has_relevant_document_supertype? will
+    # let through anything for which Whitehall would have sent emails to
+    # organisation-based lists if none of these other attributes exist on it.
+    supported_attributes = [
+      "topics",
+      "policies",
+      "service_manual_topics",
+      "taxons",
+      "world_locations",
+      "topical_events",
+      "people",
+      "policy_areas",
+      "roles",
+    ]
     supported_attributes.any? do |tag_name|
       tags_hash[tag_name] && tags_hash[tag_name].any?
     end

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -144,7 +144,6 @@ private
     channel.reject(delivery_tag, false)
   end
 
-  private
   def has_non_blank_value_for_key?(document:, key:)
     # a key can be present but the value is nil, so fetch won't
     # protect us here

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -177,6 +177,21 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "no links or tags but has a relevant document supertype" do
+      before do
+        good_document["details"] = {}
+        good_document["links"] = {}
+        good_document["email_document_supertype"] = "announcements"
+      end
+
+      it "still acknowledges and triggers the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_triggered
+        message_acknowledged
+      end
+    end
+
     context "no details hash, no links hash" do
       before { good_document.delete("links"); good_document.delete("details") }
 

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -162,6 +162,21 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "has links but is from a blacklisted publishing application" do
+      before do
+        good_document["details"] = {}
+        good_document["links"] = { "taxons" => ["taxon-uuid"] }
+        good_document["publishing_app"] = "travel-advice-publisher"
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "no details hash, no links hash" do
       before { good_document.delete("links"); good_document.delete("details") }
 


### PR DESCRIPTION
We need to trigger emails via email-alert-api for a wider range of content in order to support the Whitehall subscriptions. This change expands the list of attributes to look for in `links` and `tags`, as well as looking for the two relevant document supertype fields, and passes on more content to email-alert-api based on those checks.

We're moving towards almost all of our email alerts relying on the message queue (and therefore email-alert-service) but travel advice publisher and specialist publisher still make direct calls to email-alert-api to send their emails. We want to be particularly careful to not send those emails twice, especially when expanding the scope of the filtering, so this PR adds an extra check to explicitly exclude content from those two publishing apps.