### PR TITLE
Add check for base_path value being present

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -25,6 +25,11 @@ private
 
     document = message.parsed_document
 
+    unless has_base_path?(document)
+      @logger.info "not triggering email alert for document with no base_path: #{document}"
+      return
+    end
+
     unless has_title?(document)
       @logger.info "not triggering email alert for document with no title: #{document}"
       return
@@ -126,6 +131,10 @@ private
     return true unless document.key?("locale")
 
     document["locale"] == "en"
+  end
+
+  def has_base_path?(document)
+    has_non_blank_value_for_key?(document: document, key: "base_path")
   end
 
   def has_title?(document)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -247,6 +247,28 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "document has no base_path" do
+      before { good_document.delete("base_path") }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "document has blank base_path" do
+      before { good_document["base_path"] = nil }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "document has no title" do
       before { good_document.delete("title") }
 


### PR DESCRIPTION
`DocumentValidator` checks that 3 required fields are present as keys in the
document, but doesn't check their values. `MessageProcessor` checks the values
of two of those three plus `locale`, but wasn't checking that `base_path` had a
useful value.

When we expanded the filtering to include more content to support the
Whitehall subscriptions, we started trying to process some messages for
Whitehall contacts, which are non-addressable content items. They have a `nil`
`base_path` (in the representation that comes through on the queue, anyway) so
were passing the earlier checks but erroring when trying to construct the
message body (in `EmailAlertTemplate#make_url_from_document_base_path`).

This commit expands the earlier checks to ensure that if a message has a `nil`
`base_path` it is acknowledged and we don't try to send an email for it.