### PR TITLE
Inline the code to generate the taxon tree

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "gds-api-adapters", "40.3.0"
 gem "plek", "1.9.0"
 gem "redis", "3.1.0"
 gem "redis-namespace", "1.5.1"
-gem "govuk_taxonomy_helpers", "~> 0.1.0"
 
 group :test do
   gem 'rspec-core', '3.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,6 @@ GEM
       rest-client (~> 2.0)
     govuk_schemas (2.1.0)
       json-schema (~> 2.5.0)
-    govuk_taxonomy_helpers (0.1.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json-schema (2.5.0)
@@ -90,7 +89,6 @@ DEPENDENCIES
   bunny (~> 1.5.0)
   gds-api-adapters (= 40.3.0)
   govuk_schemas (~> 2.1)
-  govuk_taxonomy_helpers (~> 0.1.0)
   plek (= 1.9.0)
   pry-byebug
   rake

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -1,7 +1,7 @@
 require "gds_api/email_alert_api"
 require "models/lock_handler"
 require "models/email_alert_template"
-require "govuk_taxonomy_helpers"
+require "models/taxon_tree"
 
 class EmailAlert
   def initialize(document, logger)
@@ -54,16 +54,6 @@ private
   end
 
   def taxon_tree
-    return [] unless document.dig("links", "taxons")
-
-    # TODO: update the public API of the taxonomy helpers gem to also accept a
-    # single fully expanded document so that we don't have to pass in the
-    # document twice.
-    linked_content_item = GovukTaxonomyHelpers::LinkedContentItem.from_publishing_api(
-      content_item: document,
-      expanded_links: document,
-    )
-
-    linked_content_item.taxons_with_ancestors.map(&:content_id).uniq
+    TaxonTree.ancestors(document.dig("expanded_links", "taxons").to_a)
   end
 end

--- a/email_alert_service/models/taxon_tree.rb
+++ b/email_alert_service/models/taxon_tree.rb
@@ -1,0 +1,14 @@
+class TaxonTree
+  # Return all the taxons and ancestors of those taxons
+  def self.ancestors(taxons)
+    taxons.flat_map { |taxon| [taxon["content_id"]] + parent_taxon_tree(taxon) }.uniq
+  end
+
+  def self.parent_taxon_tree(taxon)
+    return [] unless taxon["links"]["parent_taxons"]
+
+    taxon["links"]["parent_taxons"].flat_map do |parent_taxon|
+      [parent_taxon["content_id"]] + parent_taxon_tree(parent_taxon)
+    end
+  end
+end


### PR DESCRIPTION
This brings the code to generate the taxon tree into this app. The taxonomy gem was part of an effort to avoid duplication between applications dealing with the taxonomy. Unfortunately we ran out of time last quarter, which left us with an API that was still in flux (https://github.com/alphagov/govuk_taxonomy_helpers/pull/11).

To avoid confusion, I think it's best to inline the code in the places where we use the taxonomy helpers. We're going to be doing work around the taxonomy in the next couple of months and I think it will be easier to extract code than trying to nail the API right now.

Trello: https://trello.com/c/FVfbiKxn