### PR TITLE
Don't assume there are links

### DIFF
--- a/email_alert_service/models/taxon_tree.rb
+++ b/email_alert_service/models/taxon_tree.rb
@@ -5,7 +5,7 @@ class TaxonTree
   end
 
   def self.parent_taxon_tree(taxon)
-    return [] unless taxon["links"]["parent_taxons"]
+    return [] unless taxon.dig("links", "parent_taxons")
 
     taxon["links"]["parent_taxons"].flat_map do |parent_taxon|
       [parent_taxon["content_id"]] + parent_taxon_tree(parent_taxon)


### PR DESCRIPTION
Links aren't a required property of frontend links [1] this code
previously assumed that links would exist and only checked for
"parent_taxons" within it. This can result in a undefined method on nil
error.

This is only a problem in testing as in production a links has is always
existent. I hesitate to add that as a required field as I don't think it
always makes sense to exist.

[1]:
https://github.com/alphagov/govuk-content-schemas/blob/master/formats/frontend_links_definition.json