### PR TITLE
Fix Sentry integration

### DIFF
--- a/bin/email_alert_service
+++ b/bin/email_alert_service
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-require 'govuk_app_config'
 
 require_relative "../email_alert_service/environment"
 rabbitmq_options = EmailAlertService.config.rabbitmq

--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -16,6 +16,8 @@ end
 require "bundler/setup"
 Bundler.require(:default, EmailAlertService.config.environment)
 
+require "govuk_app_config"
+
 EmailAlertService.config.logger.level = Logger::DEBUG
 
 Dir[File.join(EmailAlertService.config.app_root, "config/initializers/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
`govuk_app_config` is not available from within the context of the `email_alert_service` script, so we require it from `environment.rb` after rubygems has been loaded instead.