### PR TITLE
Allow rabbitmq config to be passed in as env var

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -17,3 +17,16 @@ test:
   pass: email_alert_service_test
   exchange: email_alert_service_published_documents_test_exchange
   queue: email_alert_service_published_documents_test_queue
+
+production:
+  <<: *defaults
+  hosts:
+    <% hosts = ENV['RABBITMQ_HOSTS'] || 'localhost' %>
+    <% hosts.split(",").each do |host| %>
+    - <% host %>
+    <% end %>
+  user: <% ENV['RABBITMQ_USER'] %>
+  pass: <% ENV['RABBITMQ_PASSWORD'] %>
+  exchange: <% ENV['RABBITMQ_EXCHANGE'] || 'published_documents' %>
+  queue: <% ENV['RABBITMQ_QUEUE'] || 'email_alert_service' %>
+  recover_from_connection_close: true

--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -1,6 +1,7 @@
 require "pathname"
 require "yaml"
 require "logger"
+require "erb"
 
 module EmailAlertService
   class Config
@@ -15,7 +16,7 @@ module EmailAlertService
     end
 
     def rabbitmq
-      all_configs = YAML.load(File.open(app_root+"config/rabbitmq.yml"))
+      all_configs = YAML.load(ERB.new(File.read(app_root+"config/rabbitmq.yml")).result)
       environment_config = all_configs.fetch(environment)
 
       @rabbitmq ||= symbolize_keys(environment_config).freeze


### PR DESCRIPTION
The rabbitmq hostnames are hardcoded in our deployment scripts, and this means this application won't be able to work properly with rabbitmq when running in Amazon (where we use different hostnames).

Allow the config file to be read in as ERB so we can set a conditional based upon environment variables.

https://trello.com/c/fenlgsMp/745-make-icinga-in-aws-green