### PR TITLE
Ensure redis config reads from env var

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,3 @@
-host: 127.0.0.1
+host: <% ENV['REDIS_HOST'] || '127.0.0.1' %>
 port: 6379
 namespace: email-alert-service

--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -23,7 +23,7 @@ module EmailAlertService
     end
 
     def redis_config
-      symbolize_keys(YAML.load(File.open(app_root+"config/redis.yml")))
+      symbolize_keys(YAML.load(ERB.new(File.read(app_root+"config/redis.yml")).result))
     end
 
     def logger


### PR DESCRIPTION
Ensure the redis configuration is read from env var so that all configuration is read in from environment variables set in Puppet.

https://trello.com/c/fenlgsMp/745-make-icinga-in-aws-green