### PR TITLE
Convert UTC to local time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "gds-api-adapters", "~> 47.9.0"
 gem "plek", "1.9.0"
 gem "redis", "3.1.0"
 gem "redis-namespace", "1.5.1"
+gem "tzinfo", "~> 1.2.3"
+gem "tzinfo-data", "~> 1.2017.2"
 
 group :test do
   gem 'rspec-core', '3.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,11 @@ GEM
       faraday (>= 0.7.6, < 1.0)
     slop (3.6.0)
     statsd-ruby (1.4.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2017.2)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
@@ -99,6 +104,8 @@ DEPENDENCIES
   rspec-core (= 3.6.0)
   rspec-expectations (= 3.6.0)
   rspec-mocks (= 3.6.0)
+  tzinfo (~> 1.2.3)
+  tzinfo-data (~> 1.2017.2)
   webmock (= 3.0.1)
 
 BUNDLED WITH

--- a/email_alert_service/models/email_alert_template.rb
+++ b/email_alert_service/models/email_alert_template.rb
@@ -24,7 +24,10 @@ private
   end
 
   def formatted_public_updated_at
-    DateTime.parse(@document["public_updated_at"]).strftime("%l:%M%P, %-d %B %Y")
+    # This returns the local time in London since that's what users expect to see
+    # rather than UTC
+    timezone = TZInfo::Timezone.get('Europe/London')
+    timezone.utc_to_local(DateTime.parse(@document["public_updated_at"])).strftime("%l:%M%P, %-d %B %Y")
   end
 
   def latest_change_note

--- a/spec/models/email_alert_template_spec.rb
+++ b/spec/models/email_alert_template_spec.rb
@@ -26,6 +26,28 @@ RSpec.describe EmailAlertTemplate do
   end
   let(:email_alert_template) { EmailAlertTemplate.new(document) }
 
+  describe "#formatted_public_updated_at" do
+    context "when public_updated_at is not during summer time in London" do
+      before do
+        document["public_updated_at"] = "2017-02-19T16:00:00.000+00:00"
+      end
+
+      it "returns a formatted date" do
+        expect(email_alert_template.send(:formatted_public_updated_at)).to eq(" 4:00pm, 19 February 2017")
+      end
+    end
+
+    context "when public_updated_at is during summer time in London" do
+      before do
+        document["public_updated_at"] = "2017-10-19T16:00:00.000+00:00"
+      end
+
+      it "returns a formatted date which is an hour later than public_updated_at" do
+        expect(email_alert_template.send(:formatted_public_updated_at)).to eq(" 5:00pm, 19 October 2017")
+      end
+    end
+  end
+
   describe "#latest_change_note" do
     context "no change_history is present in the document" do
       it "returns nil" do


### PR DESCRIPTION
This commit changes the output of the email-alert-api to GovDelivery to convert all times to local time in London from the default UTC that comes from publishing-api to match user expectations.

Trello: https://trello.com/c/SzDmoENZ/260-publication-date-for-whitehall-announcements-reported-in-email-digests-may-be-in-utc-not-bst