### PR TITLE
Add fields to email alert api payload

### DIFF
--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -17,6 +17,7 @@ require "bundler/setup"
 Bundler.require(:default, EmailAlertService.config.environment)
 
 require "govuk_app_config"
+require_relative 'models/change_history'
 
 EmailAlertService.config.logger.level = Logger::DEBUG
 

--- a/email_alert_service/models/change_history.rb
+++ b/email_alert_service/models/change_history.rb
@@ -1,0 +1,12 @@
+class ChangeHistory
+  attr_reader :history
+
+  def initialize(history:)
+    @history = history
+  end
+
+  def latest_change_note
+    change_note = history&.first
+    change_note["note"] if change_note
+  end
+end

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -18,6 +18,9 @@ class EmailAlert
 
   def format_for_email_api
     {
+      "title" => document["title"],
+      "description" => document["description"],
+      "change_note" => change_note,
       "subject" => document["title"],
       "body" => EmailAlertTemplate.new(document).message_body,
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
@@ -28,12 +31,19 @@ class EmailAlert
       "content_id" => document["content_id"],
       "public_updated_at" => document["public_updated_at"],
       "publishing_app" => document["publishing_app"],
+      "base_path" => document["base_path"],
     }
   end
 
 private
 
   attr_reader :document, :logger
+
+  def change_note
+    ChangeHistory.new(
+      history: document['details']['change_history']
+    ).latest_change_note
+  end
 
   def lock_handler
     LockHandler.new(document.fetch("title"), document.fetch("public_updated_at"))

--- a/email_alert_service/models/email_alert_template.rb
+++ b/email_alert_service/models/email_alert_template.rb
@@ -31,8 +31,9 @@ private
   end
 
   def latest_change_note
-    change_note = @document["details"]["change_history"]&.first
-    change_note["note"] if change_note
+    ChangeHistory.new(
+      history: @document["details"]["change_history"]
+    ).latest_change_note
   end
 
   def document_identifier_hash

--- a/spec/models/change_history_spec.rb
+++ b/spec/models/change_history_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+RSpec.describe ChangeHistory do
+  describe "#latest_change_note" do
+    context "change_history is nil" do
+      let(:change_history) { ChangeHistory.new(history: nil) }
+      it "returns nil" do
+        expect(change_history.latest_change_note).to be_nil
+      end
+    end
+
+    context "change_history has one entry" do
+      let(:change_history) {
+        ChangeHistory.new(
+          history: [
+            {
+              "public_timestamp": "2017-10-19T16:09:23.000+01:00",
+              "note" => "latest change note"
+            }
+          ]
+        )
+      }
+
+      it "returns the note" do
+        expect(change_history.latest_change_note).to eq("latest change note")
+      end
+    end
+
+    context "change_history has multiple entries" do
+      let(:change_history) {
+        ChangeHistory.new(
+          history: [
+            {
+              "public_timestamp": "2017-10-19T16:09:23.000+01:00",
+              "note" => "latest change note"
+            },
+            {
+              "public_timestamp": "2017-10-18T16:09:23.000+01:00",
+              "note" => "a different change note"
+            }
+          ]
+        )
+      }
+
+      it "returns the first" do
+        expect(change_history.latest_change_note).to eq("latest change note")
+      end
+    end
+  end
+end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -10,12 +10,23 @@ RSpec.describe EmailAlert do
       "base_path" => "/foo",
       "content_id" => content_id,
       "title" => "Example title",
+      "description" => "Example description",
       "details" => {
         "tags" => {
           "browse_pages" => ["tax/vat"],
           "topics" => ["oil-and-gas/licensing"],
           "some_other_missing_tags" => [],
-        }
+        },
+        "change_history" => [
+          {
+            "public_timestamp": "2017-10-19T16:09:23.000+01:00",
+            "note" => "latest change note"
+          },
+          {
+            "public_timestamp": "2017-10-16T12:09:00.000+01:00",
+            "note" => "old change note"
+          }
+        ]
       },
       "links" => {},
       "public_updated_at" => public_updated_at,
@@ -84,6 +95,10 @@ RSpec.describe EmailAlert do
         "document_type" => "example_document",
         "email_document_supertype" => "publications",
         "government_document_supertype" => "example_supertype",
+        "base_path" => "/foo",
+        "title" => "Example title",
+        "description" => "Example description",
+        "change_note" => "latest change note",
       )
     end
 
@@ -91,22 +106,10 @@ RSpec.describe EmailAlert do
       before { document.merge!("links" => { "topics" => ["uuid-888"] }) }
 
       it "formats the message to include the parent link" do
-        expect(email_alert.format_for_email_api).to eq(
-          "subject" => "Example title",
-          "body" => "This is an email.",
-          "content_id" => content_id,
-          "public_updated_at" => public_updated_at,
-          "publishing_app" => "Whitehall",
-          "tags" => {
-            "browse_pages" => ["tax/vat"],
-            "topics" => ["oil-and-gas/licensing"]
-          },
+        expect(email_alert.format_for_email_api).to include(
           "links" => {
             "topics" => ["uuid-888"]
-          },
-          "document_type" => "example_document",
-          "email_document_supertype" => "publications",
-          "government_document_supertype" => "example_supertype",
+          }
         )
       end
     end
@@ -118,20 +121,7 @@ RSpec.describe EmailAlert do
       end
 
       it "strips these out" do
-        expect(email_alert.format_for_email_api).to eq(
-          "subject" => "Example title",
-          "body" => "This is an email.",
-          "content_id" => content_id,
-          "public_updated_at" => public_updated_at,
-          "publishing_app" => "Whitehall",
-          "tags" => {
-            "browse_pages" => ["tax/vat"],
-          },
-          "links" => {},
-          "document_type" => "example_document",
-          "email_document_supertype" => "publications",
-          "government_document_supertype" => "example_supertype",
-        )
+        expect(email_alert.format_for_email_api["tags"]).not_to include("topics")
       end
     end
 


### PR DESCRIPTION
This PR adds the extra fields `change_note`, `base_path`, `title` and `description` to the payload sent to email-alert-api. This information is also sent within `subject` and `body` but we are moving towards making the generation of these the responsibility of email-alert-api so we need the raw data fields.

In adding the `ChangeHistory` class to encapsulate the logic for that that is used in both `EmailAlert` and `EmailAlertTemplate` now I've realised that the requiring of things in this app is all over the place and seems to be working mostly by luck.

I'll try and address that in another PR. 

[Trello](https://trello.com/c/10k5XPez/264-add-title-and-changenote-to-email-alert-service)