### PR TITLE
Require all models in environment

### DIFF
--- a/bin/delete_queue
+++ b/bin/delete_queue
@@ -3,7 +3,6 @@
 require_relative "../email_alert_service/environment"
 rabbitmq_options = EmailAlertService.config.rabbitmq
 
-require "connections/amqp_connection"
 connection = AMQPConnection.new(rabbitmq_options)
 connection.start
 channel = connection.channel

--- a/bin/email_alert_service
+++ b/bin/email_alert_service
@@ -11,7 +11,6 @@ connection.start
 require "queues/major_change_queue"
 queue_binding = MajorChangeQueue.new(connection).bind
 
-require "models/message_processor"
 message_processor = MessageProcessor.new(connection.channel, logger)
 
 require "listeners/listener"

--- a/bin/email_alert_service
+++ b/bin/email_alert_service
@@ -4,16 +4,13 @@ require_relative "../email_alert_service/environment"
 rabbitmq_options = EmailAlertService.config.rabbitmq
 logger = EmailAlertService.config.logger
 
-require "connections/amqp_connection"
 connection = AMQPConnection.new(rabbitmq_options)
 connection.start
 
-require "queues/major_change_queue"
 queue_binding = MajorChangeQueue.new(connection).bind
 
 message_processor = MessageProcessor.new(connection.channel, logger)
 
-require "listeners/listener"
 listener = Listener.new(queue_binding, message_processor)
 
 logger.info "Bound to exchange #{connection.exchange_name} on queue #{connection.queue_name}, listening for major changes"

--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -20,6 +20,6 @@ require "govuk_app_config"
 
 EmailAlertService.config.logger.level = Logger::DEBUG
 
-Dir.glob('email_alert_service/models/*.rb').each { |r| require r }
+Dir.glob('email_alert_service/**/*.rb').each { |r| require r }
 
 Dir[File.join(EmailAlertService.config.app_root, "config/initializers/**/*.rb")].each { |f| require f }

--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -17,8 +17,9 @@ require "bundler/setup"
 Bundler.require(:default, EmailAlertService.config.environment)
 
 require "govuk_app_config"
-require_relative 'models/change_history'
 
 EmailAlertService.config.logger.level = Logger::DEBUG
+
+Dir.glob('email_alert_service/models/*.rb').each { |r| require r }
 
 Dir[File.join(EmailAlertService.config.app_root, "config/initializers/**/*.rb")].each { |f| require f }

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -1,7 +1,4 @@
 require "gds_api/email_alert_api"
-require "models/lock_handler"
-require "models/email_alert_template"
-require "models/taxon_tree"
 
 class EmailAlert
   def initialize(document, logger)

--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'models/message_identifier'
 
 class LockHandler
   class AlreadyLocked < StandardError; end

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -1,6 +1,3 @@
-require "models/email_alert"
-require "models/message"
-
 class MessageProcessor
   def initialize(channel, logger)
     @channel = channel

--- a/spec/connections/connection_spec.rb
+++ b/spec/connections/connection_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "connections/amqp_connection"
 
 RSpec.describe AMQPConnection do
   let(:config_options) { { exchange: "example exchange", queue: "example queue" } }

--- a/spec/integration/random_input_spec.rb
+++ b/spec/integration/random_input_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "models/message_processor"
 
 RSpec.describe "Random input", type: :integration do
   let(:delivery_info) { double(:delivery_info, delivery_tag: double(:delivery_tag)) }

--- a/spec/listeners/listener_spec.rb
+++ b/spec/listeners/listener_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "listeners/listener"
 
 RSpec.describe Listener do
   describe "#listen" do

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "models/message_processor"
 
 RSpec.describe MessageProcessor do
   let(:delivery_tag) { double(:delivery_tag) }

--- a/spec/queues/major_change_queue_spec.rb
+++ b/spec/queues/major_change_queue_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "queues/major_change_queue"
 
 RSpec.describe MajorChangeQueue do
   describe "#bind" do

--- a/spec/support/listener_test_helpers.rb
+++ b/spec/support/listener_test_helpers.rb
@@ -1,7 +1,4 @@
-require "connections/amqp_connection"
-require "listeners/listener"
 require "logger"
-require "queues/major_change_queue"
 require "tempfile"
 require "timeout"
 

--- a/spec/support/listener_test_helpers.rb
+++ b/spec/support/listener_test_helpers.rb
@@ -1,7 +1,6 @@
 require "connections/amqp_connection"
 require "listeners/listener"
 require "logger"
-require "models/message_processor"
 require "queues/major_change_queue"
 require "tempfile"
 require "timeout"


### PR DESCRIPTION
Prior to this commit models were required in a couple of places that as luck would have it made them available where the were needed.

When trying to add another model ([in another PR](https://github.com/alphagov/email-alert-service/pull/86)) it wasn't clear why it was undefined in its specs but other models seemingly got required by magic.

This commit loads all models in the environment which is included in both spec_helper and the application entry point - bin/email_alert_service.

Should we do this for the other objects? `connections`, `listeners` and `queues`?