### PR TITLE
Add bearer token for email-alert-api

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -47,7 +47,10 @@ private
   end
 
   def email_api_client
-    GdsApi::EmailAlertApi.new(Plek.find("email-alert-api"))
+    GdsApi::EmailAlertApi.new(
+      Plek.find("email-alert-api"),
+      bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "email-alert-api-bearer-token")
+    )
   end
 
   def strip_empty_arrays(tag_hash)


### PR DESCRIPTION
Email-alert-api is getting authentication and authorisation. This commit adds a bearer token for it when creating the client.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)