### PR TITLE
Revert "Bump bunny from 1.5.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "bunny", "~> 2.8.0"
+gem "bunny", "~> 1.5.0"
 gem "gds-api-adapters", "~> 50.8.0"
 gem "govuk_app_config", "~> 1.1.0"
 gem "plek", "2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GEM
     addressable (2.3.8)
     amq-protocol (2.2.0)
     ast (2.3.0)
-    bunny (2.8.0)
-      amq-protocol (>= 2.2.0)
+    bunny (1.5.1)
+      amq-protocol (>= 1.9.2)
     byebug (9.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -146,7 +146,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bunny (~> 2.8.0)
+  bunny (~> 1.5.0)
   gds-api-adapters (~> 50.8.0)
   govuk-lint (= 3.3.0)
   govuk_app_config (~> 1.1.0)


### PR DESCRIPTION
Reverts alphagov/email-alert-service#100

This broke the ability for email-alert-service to connect to the Rabbit MQ.

```
W, [2017-12-29T10:19:37.347426 #28223]  WARN -- #<Bunny::Session:0x7f78baaadd60 @localhost:5672, vhost=, addresses=[localhost:5672]>: Connection options contain both a host and an array of hosts (addresses), please pick one.
W, [2017-12-29T10:19:37.348853 #28223]  WARN -- #<Bunny::Session:0x7f78baaadd60 email_alert_service@localhost:5672, vhost=/, addresses=[localhost:5672]>: Could not establish TCP connection to localhost:5672: Connection refused - connect(2) for 127.0.0.1:5672
```