### PR TITLE
Blacklist coming_soon document_type from emails

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -55,7 +55,9 @@ private
   end
 
   def email_alerts_supported?(document)
-    return false if blacklisted_publishing_app?(document["publishing_app"])
+    blacklisted = blacklisted_publishing_app?(document["publishing_app"]) \
+      || blacklisted_document_type?(document["document_type"])
+    return false if blacklisted
 
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
@@ -98,6 +100,12 @@ private
     # emails, so we need to avoid sending duplicate emails when they come
     # through on the queue:
     ['travel-advice-publisher', 'specialist-publisher'].include?(publishing_app)
+  end
+
+  def blacklisted_document_type?(document_type)
+    # These are documents that don't make sense to email someone about as they
+    # are not useful to an end user.
+    %w[coming_soon].include?(document_type)
   end
 
   def whitelisted_document_type?(document_type)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -176,6 +176,21 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "has links but is from a blacklisted document type" do
+      before do
+        good_document["details"] = {}
+        good_document["links"] = { "taxons" => ["taxon-uuid"] }
+        good_document["document_type"] = "coming_soon"
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "no links or tags but has a relevant document supertype" do
       before do
         good_document["details"] = {}


### PR DESCRIPTION
Trello: https://trello.com/c/Uo9V91U4/481-stop-sending-email-alerts-for-content-that-is-coming-soon

These shouldn't be sent out as emails as it means users just receive a
message that says "coming soon" which isn't useful to the user.