### PR TITLE
Assign high priorities to travel advice and medical safety documents

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -29,6 +29,7 @@ class EmailAlert
       "public_updated_at" => document["public_updated_at"],
       "publishing_app" => document["publishing_app"],
       "base_path" => document["base_path"],
+      "priority" => priority,
     }
   end
 
@@ -65,5 +66,9 @@ private
 
   def taxon_tree
     TaxonTree.ancestors(document.dig("expanded_links", "taxons").to_a)
+  end
+
+  def priority
+    "normal"
   end
 end

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -1,6 +1,8 @@
 require "gds_api/email_alert_api"
 
 class EmailAlert
+  HIGH_PRIORITY_DOCUMENT_TYPES = %w(travel_advice).freeze
+
   def initialize(document, logger)
     @document = document
     @logger = logger
@@ -69,6 +71,6 @@ private
   end
 
   def priority
-    "normal"
+    HIGH_PRIORITY_DOCUMENT_TYPES.include?(document.fetch("document_type")) ? "high" : "normal"
   end
 end

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -1,7 +1,7 @@
 require "gds_api/email_alert_api"
 
 class EmailAlert
-  HIGH_PRIORITY_DOCUMENT_TYPES = %w(travel_advice).freeze
+  HIGH_PRIORITY_DOCUMENT_TYPES = %w(travel_advice medical_safety_alert).freeze
 
   def initialize(document, logger)
     @document = document

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe EmailAlert do
         "title" => "Example title",
         "description" => "Example description",
         "change_note" => "latest change note",
+        "priority" => "normal",
       )
     end
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -160,5 +160,15 @@ RSpec.describe EmailAlert do
         expect(links_hash["taxon_tree"].sort).to eq %w(uuid-1 uuid-2 uuid-3)
       end
     end
+
+    context "with a travel advice" do
+      before do
+        document.merge!("document_type" => "travel_advice")
+      end
+
+      it "should be high priority" do
+        expect(email_alert.format_for_email_api["priority"]).to eq("high")
+      end
+    end
   end
 end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -170,5 +170,15 @@ RSpec.describe EmailAlert do
         expect(email_alert.format_for_email_api["priority"]).to eq("high")
       end
     end
+
+    context "with a medical safety alert" do
+      before do
+        document.merge!("document_type" => "medical_safety_alert")
+      end
+
+      it "should be high priority" do
+        expect(email_alert.format_for_email_api["priority"]).to eq("high")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR makes sure that travel advice documents and medical safety alerts will be sent out as high priority emails.

Those documents do not currently go through the email alert service, but this will be ready for when they do.

Depends on https://github.com/alphagov/email-alert-api/pull/382

[Trello Card](https://trello.com/c/mHXNdskh/550-setup-delivery-priorities)