### PR TITLE
Blacklist collections-publisher

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -101,6 +101,10 @@ private
     # through on the queue:
     return true if %w(travel-advice-publisher specialist-publisher).include?(publishing_app)
 
+    # These publishing apps don't manage any content where it would make sense to
+    # subscribe to email updates for
+    return true if %w(collections-publisher).include?(publishing_app)
+
     false
   end
 

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -99,7 +99,9 @@ private
     # These publishing apps make direct calls to email-alert-api to send their
     # emails, so we need to avoid sending duplicate emails when they come
     # through on the queue:
-    ['travel-advice-publisher', 'specialist-publisher'].include?(publishing_app)
+    return true if %w(travel-advice-publisher specialist-publisher).include?(publishing_app)
+
+    false
   end
 
   def blacklisted_document_type?(document_type)


### PR DESCRIPTION
This app doesn't manage any content where it would make sense to subscribe to email updates.

[Trello Card](https://trello.com/c/X27iZdG5/568-blacklist-content-changes-from-collections-publisher-in-email-alert-service)