### PR TITLE
Don't retry 409s from email-alert-api

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -11,7 +11,11 @@ class EmailAlert
   def trigger
     logger.info "Received major change notification for #{document['title']}, with details #{document['details']}"
     lock_handler.with_lock_unless_done do
-      email_api_client.send_alert(format_for_email_api, govuk_request_id: document['govuk_request_id'])
+      begin
+        email_api_client.send_alert(format_for_email_api, govuk_request_id: document['govuk_request_id'])
+      rescue GdsApi::HTTPConflict
+        logger.info "email-alert-api returned conflict for #{document['content_id']}, #{document['base_path']}, #{document['public_updated_at']}"
+      end
     end
   end
 

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -71,6 +71,15 @@ RSpec.describe EmailAlert do
         govuk_request_id: govuk_request_id
       )
     end
+
+    it "logs if it receives a conflict" do
+      allow(alert_api).to receive(:send_alert).and_raise(GdsApi::HTTPConflict.new(409))
+      email_alert.trigger
+
+      expect(logger).to have_received(:info).with(
+        "email-alert-api returned conflict for #{document['content_id']}, #{document['base_path']}, #{document['public_updated_at']}"
+      )
+    end
   end
 
   describe "#format_for_email_api" do


### PR DESCRIPTION
Email-alert-api now checks for duplicate content changes and returns a 409 if they are received.

This PR rescues and logs the GdsApi::HTTPConflict that will be raised by the adapter.