### PR TITLE
Don't send descriptions for travel advice emails

### DIFF
--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -178,6 +178,10 @@ RSpec.describe EmailAlert do
       it "should be high priority" do
         expect(email_alert.format_for_email_api["priority"]).to eq("high")
       end
+
+      it "should have a blank description" do
+        expect(email_alert.format_for_email_api["description"]).to eq("")
+      end
     end
 
     context "with a medical safety alert" do


### PR DESCRIPTION
We've found the descriptions to be excessively long so we don't want them to be included in emails.

[Trello Card](https://trello.com/c/2MgWX34y/642-change-what-we-put-in-travel-advice-updates)