### PR TITLE
Don't process a message without a change note

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -32,6 +32,11 @@ private
       return
     end
 
+    unless has_change_note?(document)
+      @logger.info "not triggering email alert for document with no change note: #{document}"
+      return
+    end
+
     unless has_public_updated_at?(document)
       @logger.info "not triggering email alert for document with no public_updated_at: #{document}"
       return
@@ -146,6 +151,10 @@ private
 
   def has_title?(document)
     has_non_blank_value_for_key?(document: document, key: "title")
+  end
+
+  def has_change_note?(document)
+    has_non_blank_value_for_key?(document: document, key: "change_note")
   end
 
   def has_public_updated_at?(document)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -294,6 +294,17 @@ RSpec.describe MessageProcessor do
       end
     end
 
+    context "document has no change note" do
+      before { good_document["change_note"] = nil }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
     context "document has blank title" do
       before { good_document["title"] = nil }
 


### PR DESCRIPTION
This will fail validation errors anyway when it gets to `email-alert-api`.