### PR TITLE
Blacklist special route document types

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -111,7 +111,7 @@ private
   def blacklisted_document_type?(document_type)
     # These are documents that don't make sense to email someone about as they
     # are not useful to an end user.
-    %w[coming_soon].include?(document_type)
+    %w[coming_soon special_route].include?(document_type)
   end
 
   def whitelisted_document_type?(document_type)

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -180,10 +180,20 @@ RSpec.describe MessageProcessor do
       before do
         good_document["details"] = {}
         good_document["links"] = { "taxons" => ["taxon-uuid"] }
-        good_document["document_type"] = "coming_soon"
       end
 
-      it "acknowledges but doesn't trigger the email" do
+      it "acknowledges but doesn't trigger the email for coming_soon document type" do
+        good_document["document_type"] = "coming_soon"
+
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+
+      it "acknowledges but doesn't trigger the email for special_route document type" do
+        good_document["document_type"] = "special_route"
+
         processor.process(good_document.to_json, properties, delivery_info)
 
         email_was_not_triggered


### PR DESCRIPTION
These aren't the kind of document types we would expect users to need to subscribe to.