### PR TITLE
Don't send emails for documents without a change note

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -42,6 +42,11 @@ private
       return
     end
 
+    unless has_change_note?(document)
+      @logger.info "not triggering email alert for document missing change note #{document}"
+      return
+    end
+
     if email_alerts_supported?(document)
       @logger.info "triggering email alert for document #{document['title']}"
       trigger_email_alert(document)
@@ -150,6 +155,14 @@ private
 
   def has_public_updated_at?(document)
     has_non_blank_value_for_key?(document: document, key: "public_updated_at")
+  end
+
+  def has_change_note?(document)
+    note = ChangeHistory.new(
+      history: document.dig("details", "change_history")
+    ).latest_change_note
+
+    !note.nil? && !note.empty?
   end
 
   def acknowledge(message)

--- a/spec/integration/major_changes_spec.rb
+++ b/spec/integration/major_changes_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe "Receiving major change notifications", type: :integration do
       "description" => "example description",
       "public_updated_at" => updated_now,
       "details" => {
-        "change_note" => "this doc has been changed",
+        "change_history" => [
+          {
+            "note" => "First published.",
+            "public_timestamp" => "2014-10-06T13:39:19.000+00:00"
+          }
+        ],
         "tags" => {
           "browse_pages" => [],
           "topics" => ["example topic"]


### PR DESCRIPTION
This checks the documents that are plucked from the queue to see if they
have a change note, if they do not they are not sent to email-alert-api.