### PR TITLE
Don’t send emails for HMCTS content items

### DIFF
--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -71,6 +71,15 @@ private
     document_links = document.fetch("links", {})
     document_type = document.fetch("document_type")
 
+    # Temporarily stop HMCTS-related content items from triggering
+    # email alerts while their forms are migrated to GOV.UK.
+    # This will be removed on 21/03/2018.
+    # This only works if HMCTS is the first organisation, which will
+    # be the case here.
+    document_expanded_links = document.fetch("expanded_links", {})
+    return false if document_expanded_links.dig("organisations", 0, "base_path") ==
+        "/government/organisations/hm-courts-and-tribunals-service"
+
     contains_supported_attribute?(document_links) \
       || contains_supported_attribute?(document_tags) \
       || whitelisted_document_type?(document_type) \

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -37,6 +37,30 @@ RSpec.describe MessageProcessor do
     }
   end
 
+  let(:hmcts_document) do
+    {
+      "base_path" => "path/to-doc",
+      "title" => "Example title",
+      "document_type" => "example",
+      "description" => "example description",
+      "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      "details" => {
+        "change_history" => change_history,
+        "tags" => {
+          "topics" => ["example topic"]
+        }
+      },
+      "expanded_links" => {
+        "topics" => ["example-topic-uuid"],
+        "organisations" => [
+          {
+            "base_path" => "/government/organisations/hm-courts-and-tribunals-service"
+          }
+        ]
+      }
+    }
+  end
+
   def email_was_triggered
     expect(mock_email_alert).to have_received(:trigger)
   end
@@ -196,6 +220,15 @@ RSpec.describe MessageProcessor do
         processor.process(good_document.to_json, properties, delivery_info)
 
         email_was_triggered
+        message_acknowledged
+      end
+    end
+
+    context "organisation is HMCTS" do
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(hmcts_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
         message_acknowledged
       end
     end


### PR DESCRIPTION
This commit blocks HMCTS content items from triggering emails. This will be used temporarily whilst HMCTS forms are migrated to GOV.UK to stop them generating emails and will be removed once the migration is complete.

Trello: https://trello.com/c/n2DVjtf7/573-stop-emails-being-sent-for-hmcts-forms-migration