### PR TITLE
Always pick the latest change note regardless of order

### DIFF
--- a/email_alert_service/models/change_history.rb
+++ b/email_alert_service/models/change_history.rb
@@ -6,7 +6,7 @@ class ChangeHistory
   end
 
   def latest_change_note
-    change_note = history&.first
+    change_note = history&.sort_by { |note| note["public_timestamp"] }&.last
     change_note["note"] if change_note
   end
 end

--- a/spec/models/change_history_spec.rb
+++ b/spec/models/change_history_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe ChangeHistory do
         ChangeHistory.new(
           history: [
             {
-              "public_timestamp": "2017-10-19T16:09:23.000+01:00",
-              "note" => "latest change note"
-            },
-            {
               "public_timestamp": "2017-10-18T16:09:23.000+01:00",
               "note" => "a different change note"
+            },
+            {
+              "public_timestamp": "2017-10-19T16:09:23.000+01:00",
+              "note" => "latest change note"
             }
           ]
         )
       }
 
-      it "returns the first" do
+      it "returns the latest" do
         expect(change_history.latest_change_note).to eq("latest change note")
       end
     end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe EmailAlert do
         },
         "change_history" => [
           {
-            "public_timestamp": "2017-10-19T16:09:23.000+01:00",
+            "public_timestamp" => "2017-10-19T16:09:23.000+01:00",
             "note" => "latest change note"
           },
           {
-            "public_timestamp": "2017-10-16T12:09:00.000+01:00",
+            "public_timestamp" => "2017-10-16T12:09:00.000+01:00",
             "note" => "old change note"
           }
         ]

--- a/spec/models/message_processor_spec.rb
+++ b/spec/models/message_processor_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe MessageProcessor do
     [
       {
         "note" => "First published.",
-        "public_timestamp" => "2014-10-06T13:39:19.000+00:00"
-      }
+        "public_timestamp" => "2014-10-06T13:39:19.000+00:00",
+      },
     ]
   end
 


### PR DESCRIPTION
This ignores the order of the change notes in the array and instead sorts by the date so it is always the latest one.

[Trello Card](https://trello.com/c/APBoUkYx/732-investigate-change-history-handling-in-email-alert-service)