### PR TITLE
Create dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.5.1
+
+ENV RABBITMQ_HOSTS rabbitmq
+ENV RABBITMQ_USER guest
+ENV RABBITMQ_PASSWORD guest
+ENV RABBITMQ_EXCHANGE published_documents
+ENV RAILS_ENV development
+ENV REDIS_HOST redis
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+ADD Gemfile* $APP_HOME/
+RUN bundle install
+ADD . $APP_HOME
+
+CMD bin/email_alert_service


### PR DESCRIPTION
Trello: https://trello.com/c/U9nNDFrH/222-decide-on-whether-e2e-tests-should-include-email-alert-api-following-on-from-content-tagger-work

This will allow this repo to be run as part of publishing-e2e-tests and
any other docker stuff we do on GOV.UK.