### PR TITLE
Enable unpublish events to be forwarded to email-api-service

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -48,7 +48,7 @@ production:
     - processor: major_change_message_processor
       name: <%= ENV['RABBITMQ_QUEUE'] || 'email_alert_service' %>
       routing_key: "*.major.#"
-    #- processor: unpublishing_message_processor
-    #  name: email_unpublishing
-    #  routing_key: "redirect.unpublishing.#"
+    - processor: unpublishing_message_processor
+      name: email_unpublishing
+      routing_key: "redirect.unpublishing.#"
 


### PR DESCRIPTION
During deployment of the updates to the email-alert-service (https://github.com/alphagov/email-alert-service/pull/178) email-alert-api (https://github.com/alphagov/email-alert-api/pull/655) and the gds-api-adapters (https://github.com/alphagov/gds-api-adapters/pull/846),
the unpublishing events were temporarily disable to enable testing of these modules
individually

This PR enables the unpublishing events

trello: https://trello.com/c/fPAplaaV/67-send-notifications-when-unpublishing-taxons