### PR TITLE
Fix a mistake in the routing key

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -50,5 +50,5 @@ production:
       routing_key: "*.major.#"
     - processor: unpublishing_message_processor
       name: email_unpublishing
-      routing_key: "redirect.unpublishing.#"
+      routing_key: "redirect.unpublish.#"
 


### PR DESCRIPTION
The routing key for unpublishing messages was incorrect. This PR fixes that.