### PR TITLE
Don't blacklist Travel Advice and Specialist Publisher

### DIFF
--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -83,11 +83,6 @@ protected
   end
 
   def blacklisted_publishing_app?(publishing_app)
-    # These publishing apps make direct calls to email-alert-api to send their
-    # emails, so we need to avoid sending duplicate emails when they come
-    # through on the queue:
-    return true if %w(travel-advice-publisher specialist-publisher).include?(publishing_app)
-
     # These publishing apps don't manage any content where it would make sense to
     # subscribe to email updates for
     return true if %w(collections-publisher).include?(publishing_app)


### PR DESCRIPTION
We want to stop these apps from talking directly to email-alert-api so we need to let them through email-alert-service.