### PR TITLE
Stop blacklisting travel-advice-publisher

### DIFF
--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -86,7 +86,7 @@ protected
     # These publishing apps make direct calls to email-alert-api to send their
     # emails, so we need to avoid sending duplicate emails when they come
     # through on the queue:
-    return true if %w(travel-advice-publisher specialist-publisher).include?(publishing_app)
+    return true if %w(specialist-publisher).include?(publishing_app)
 
     # These publishing apps don't manage any content where it would make sense to
     # subscribe to email updates for

--- a/spec/models/major_change_message_processor_spec.rb
+++ b/spec/models/major_change_message_processor_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe MajorChangeMessageProcessor do
       before do
         good_document["details"] = { "change_history" => change_history }
         good_document["links"] = { "taxons" => ["taxon-uuid"] }
-        good_document["publishing_app"] = "travel-advice-publisher"
+        good_document["publishing_app"] = "specialist-publisher"
       end
 
       it "acknowledges but doesn't trigger the email" do


### PR DESCRIPTION
We want travel-advice-publisher to stop talking directly to email-alert-api.