### PR TITLE
Fix exception handling

### DIFF
--- a/email_alert_service/listeners/listener.rb
+++ b/email_alert_service/listeners/listener.rb
@@ -30,7 +30,7 @@ private
   end
 
   def exit_on_exception(exception, document_json, properties, delivery_info)
-    logger.error("Error processing message #{delivery_info.delivery_tag}: #{e.class} (#{e.message})\n#{e.backtrace.join("\n")}")
+    logger.error("Error processing message #{delivery_info.delivery_tag}: #{exception.class} (#{exception.message})\n#{exception.backtrace.join("\n")}")
     # Rescue any exception, not just StandardError and subclasses.
     # We want to ensure that the process exits in such a situation, so we
     # explicitly call exit() after logging the error.


### PR DESCRIPTION
Currently when an exception occurs, we try and access a variable called `e` which doesn't exist. This means the whole program crashes but upstart doesn't restart it since it hasn't exited, it's just blocking.

I think this is the reason why we've seen email-alert-service sometimes stop processing the queue, and it seems related to when RabbitMQ is unreachable in some way. Hopefully this fix should mean that we can see what the error is next time.

It looks like this bug was introduced in https://github.com/alphagov/email-alert-service/commit/658816212c418541187598713dbcca921f3cb3ef.