### PR TITLE
Add a test to check process exits cleanly

### DIFF
--- a/spec/listeners/listener_spec.rb
+++ b/spec/listeners/listener_spec.rb
@@ -1,18 +1,33 @@
 require "spec_helper"
 
 RSpec.describe Listener do
+  let(:queue_binding) { double(:queue_binding) }
+  let(:handler) { double(:handler) }
+
+  subject(:listener) { described_class.new(queue_binding, handler) }
+
   describe "#listen" do
     it "subscribes to the queue binding with manual acknowledgements,
         blocking the thread" do
-      queue_binding = double(:queue_binding)
-      handler = double(:handler)
-
       expect(queue_binding).to receive(:subscribe).with(
         block: false,
         manual_ack: true,
       )
 
-      Listener.new(queue_binding, handler).listen
+      listener.listen
+    end
+
+    context "when an error occurs processing a message" do
+      before do
+        delivery_info = double(delivery_tag: nil)
+        allow(queue_binding).to receive(:subscribe) { |&block| block.call delivery_info, {}, {} }
+        expect(handler).to receive(:process).and_raise("a problem has occured")
+      end
+
+      it "exits cleanly and reports the error" do
+        expect(GovukError).to receive(:notify)
+        expect { listener.listen }.to raise_error(SystemExit)
+      end
     end
   end
 end


### PR DESCRIPTION
If an error occurs while processing a message, the app should report the error and exit cleanly. We had an incident recently where this process wasn't working correctly and ended up leaving the service running but not processing anything.

[Trello Card](https://trello.com/c/Nq48ujFz/871-add-a-test-to-email-alert-service-for-when-the-connection-to-rabbitmq-is-lost)