### PR TITLE
Process workflow notifications

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -17,6 +17,9 @@ development:
     - processor: unpublishing_message_processor
       name: email_unpublishing
       routing_key: 'redirect.unpublishing.#'
+    - processor: workflow_message_processor
+      name: email_alert_service_workflow
+      routing_key: "*.workflow.#"
 
 test:
   <<: *defaults
@@ -31,6 +34,9 @@ test:
     - processor: unpublishing_message_processor
       name: email_alert_service_unpublishing_documents_test_queue
       routing_key: "redirect.unpublishing.#"
+    - processor: workflow_message_processor
+      name: email_alert_service_workflow_test_queue
+      routing_key: "*.workflow.#"
 
 production:
   <<: *defaults
@@ -51,4 +57,7 @@ production:
     - processor: unpublishing_message_processor
       name: email_unpublishing
       routing_key: "redirect.unpublish.#"
+    - processor: workflow_message_processor
+      name: <%= ENV['RABBITMQ_QUEUE'] || 'email_alert_service_workflow' %>
+      routing_key: "*.workflow.#"
 

--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -1,37 +1,15 @@
 require_relative('./message_processor')
+require_relative('./message_processor_validator')
 
 class MajorChangeMessageProcessor < MessageProcessor
+  include MessageProcessorValidator
+
 protected
 
   def process_message(message)
     document = message.parsed_document
 
-    unless has_base_path?(document)
-      @logger.info "not triggering email alert for document with no base_path: #{document}"
-      return
-    end
-
-    unless has_title?(document)
-      @logger.info "not triggering email alert for document with no title: #{document}"
-      return
-    end
-
-    unless has_public_updated_at?(document)
-      @logger.info "not triggering email alert for document with no public_updated_at: #{document}"
-      return
-    end
-
-    unless is_english?(document)
-      @logger.info "not triggering email alert for non-english document #{document['title']}: locale #{document['locale']}"
-      return
-    end
-
-    unless has_change_note?(document)
-      @logger.info "not triggering email alert for document missing change note #{document}"
-      return
-    end
-
-    if email_alerts_supported?(document)
+    if valid?(document) && email_alerts_supported?(document)
       @logger.info "triggering email alert for document #{document['title']}"
       trigger_email_alert(document)
     end
@@ -118,40 +96,5 @@ protected
     # so are limiting the scope of emails to approximately what Whitehall did.
     relevant_supertype.call(document["government_document_supertype"]) ||
       relevant_supertype.call(document["email_document_supertype"])
-  end
-
-  def is_english?(document)
-    # A missing locale is assumed to be English, but a "null" locale is not
-    return true unless document.key?("locale")
-
-    document["locale"] == "en"
-  end
-
-  def has_base_path?(document)
-    has_non_blank_value_for_key?(document: document, key: "base_path")
-  end
-
-  def has_title?(document)
-    has_non_blank_value_for_key?(document: document, key: "title")
-  end
-
-  def has_public_updated_at?(document)
-    has_non_blank_value_for_key?(document: document, key: "public_updated_at")
-  end
-
-  def has_change_note?(document)
-    note = ChangeHistory.new(
-      history: document.dig("details", "change_history")
-    ).latest_change_note
-
-    !note.nil? && !note.empty?
-  end
-
-  def has_non_blank_value_for_key?(document:, key:)
-    # a key can be present but the value is nil, so fetch won't
-    # protect us here
-    return false unless document.key?(key)
-
-    (document[key] || "") != ""
   end
 end

--- a/email_alert_service/models/message_processor_validator.rb
+++ b/email_alert_service/models/message_processor_validator.rb
@@ -1,0 +1,67 @@
+module MessageProcessorValidator
+  def valid?(document)
+    unless has_base_path?(document)
+      @logger.info "not triggering email alert for document with no base_path: #{document}"
+      return false
+    end
+
+    unless has_title?(document)
+      @logger.info "not triggering email alert for document with no title: #{document}"
+      return false
+    end
+
+    unless has_public_updated_at?(document)
+      @logger.info "not triggering email alert for document with no public_updated_at: #{document}"
+      return false
+    end
+
+    unless is_english?(document)
+      @logger.info "not triggering email alert for non-english document #{document['title']}: locale #{document['locale']}"
+      return false
+    end
+
+    unless has_change_note?(document)
+      @logger.info "not triggering email alert for document missing change note #{document}"
+      return false
+    end
+
+    true
+  end
+
+private
+
+  def is_english?(document)
+    # A missing locale is assumed to be English, but a "null" locale is not
+    return true unless document.key?("locale")
+
+    document["locale"] == "en"
+  end
+
+  def has_base_path?(document)
+    has_non_blank_value_for_key?(document: document, key: "base_path")
+  end
+
+  def has_title?(document)
+    has_non_blank_value_for_key?(document: document, key: "title")
+  end
+
+  def has_public_updated_at?(document)
+    has_non_blank_value_for_key?(document: document, key: "public_updated_at")
+  end
+
+  def has_change_note?(document)
+    note = ChangeHistory.new(
+      history: document.dig("details", "change_history")
+    ).latest_change_note
+
+    !note.nil? && !note.empty?
+  end
+
+  def has_non_blank_value_for_key?(document:, key:)
+    # a key can be present but the value is nil, so fetch won't
+    # protect us here
+    return false unless document.key?(key)
+
+    (document[key] || "") != ""
+  end
+end

--- a/email_alert_service/models/workflow_message_processor.rb
+++ b/email_alert_service/models/workflow_message_processor.rb
@@ -1,0 +1,56 @@
+require_relative('./message_processor')
+require_relative('./message_processor_validator')
+
+class WorkflowMessageProcessor < MessageProcessor
+  include MessageProcessorValidator
+
+  WHITELISTED_PUBLISHING_APPS = %w[content-tagger].freeze
+
+protected
+
+  def process_message(message)
+    document = message.parsed_document
+
+    if valid_message?(document) && email_alerts_supported?(document)
+      @logger.info "triggering email alert for document #{document['title']}"
+      trigger_email_alert(document)
+    end
+  end
+
+  def trigger_email_alert(document)
+    EmailAlert.new(document, @logger).trigger
+  end
+
+  def email_alerts_supported?(document)
+    whitelisted_publishing_app?(document["publishing_app"]) &&
+      valid_workflow?(document)
+  end
+
+  def whitelisted_publishing_app?(publishing_app)
+    return true if WHITELISTED_PUBLISHING_APPS.include?(publishing_app)
+
+    false
+  end
+
+  def valid_message?(document)
+    unless has_workflow_message?(document)
+      @logger.info "not triggering email alert for document with no workflow message"
+
+      return false
+    end
+
+    valid?(document)
+  end
+
+  def has_workflow_message?(document)
+    has_non_blank_value_for_key?(document: document, key: "workflow_message")
+  end
+
+  # Tagging documents with facets is (currently) the only workflow permitted
+  # for generating notifications.
+  def valid_workflow?(document)
+    document_links = document.fetch("links", {})
+    document_links.fetch("facet_groups", []).any? &&
+      document_links.fetch("facet_values", []).any?
+  end
+end

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -89,6 +89,26 @@ RSpec.describe EmailAlert do
         "email-alert-api returned unprocessable entity for #{document['content_id']}, #{document['base_path']}, #{document['public_updated_at']}"
       )
     end
+
+    context "for a workflow notification" do
+      before do
+        document["workflow_message"] = "Something changed"
+        email_alert.trigger
+      end
+
+      it "logs receiving a workflow notification for a document" do
+        expect(logger).to have_received(:info).with(
+          "Received workflow message notification for #{document['title']}, with details #{document['details']}"
+        )
+      end
+
+      it "prefers the workflow message to the change note" do
+        expect(alert_api).to have_received(:send_alert).with(
+          hash_including("change_note" => "Something changed"),
+          govuk_request_id: govuk_request_id
+        )
+      end
+    end
   end
 
   describe "#format_for_email_api" do

--- a/spec/models/workflow_message_processor_spec.rb
+++ b/spec/models/workflow_message_processor_spec.rb
@@ -1,0 +1,140 @@
+require "spec_helper"
+
+RSpec.describe WorkflowMessageProcessor do
+  let(:delivery_tag) { double(:delivery_tag) }
+  let(:delivery_info) { double(:delivery_info, delivery_tag: delivery_tag) }
+  let(:properties) { double(:properties, content_type: nil) }
+  let(:channel) { double(:channel, acknowledge: nil, reject: nil, nack: nil) }
+  let(:logger) { double(:logger, info: nil) }
+
+  let(:processor) { WorkflowMessageProcessor.new(channel, logger) }
+  let(:mock_email_alert) { double("EmailAlert", trigger: nil) }
+  let(:change_history) do
+    [
+      {
+        "note" => "First published.",
+        "public_timestamp" => "2014-10-06T13:39:19.000+00:00",
+      },
+    ]
+  end
+
+  let(:good_document) do
+    {
+      "base_path" => "path/to-doc",
+      "title" => "Example title",
+      "document_type" => "example",
+      "description" => "example description",
+      "public_updated_at" => "2014-10-06T13:39:19.000+00:00",
+      "publishing_app" => "content-tagger",
+      "details" => {
+        "change_history" => change_history,
+      },
+      "links" => {
+        "facet_groups" => ["example-facet-group-uuid"],
+        "facet_values" => ["example-facet-value-uuid"],
+      },
+      "workflow_message" => "Something important changed",
+    }
+  end
+
+  def email_was_triggered
+    expect(mock_email_alert).to have_received(:trigger)
+  end
+
+  def email_was_not_triggered
+    expect(mock_email_alert).to_not have_received(:trigger)
+  end
+
+  def message_acknowledged
+    expect(channel).to have_received(:acknowledge).with(delivery_tag, false)
+  end
+
+  before do
+    allow(EmailAlert).to receive(:new).and_return(mock_email_alert)
+  end
+
+  describe "#process" do
+    it "acknowledges and triggers the email for a correctly tagged document" do
+      processor.process(good_document.to_json, properties, delivery_info)
+
+      email_was_triggered
+      message_acknowledged
+    end
+
+    context "document with empty tags" do
+      before do
+        good_document["details"]["tags"] = { "facet_groups" => [], "facet_values" => [] }
+        good_document["links"] = { "facet_groups" => [], "facet_values" => [] }
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "document with missing tag fields" do
+      before do
+        good_document["links"].delete("facet_groups")
+        good_document["details"].delete("tags")
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "empty change note" do
+      before do
+        good_document["details"]["change_history"][0]["note"] = ""
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "missing change history" do
+      before do
+        good_document["details"]["change_history"] = nil
+      end
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "missing details hash" do
+      before { good_document.delete("details") }
+
+      it "acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+
+    context "missing links hash" do
+      before { good_document.delete("links") }
+
+      it "still acknowledges but doesn't trigger the email" do
+        processor.process(good_document.to_json, properties, delivery_info)
+
+        email_was_not_triggered
+        message_acknowledged
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/0wiO10tC/327-email-trigger-mechanism-for-new-content-tagger-process

Adds a processor to handle non-major-update workflow event notifications.
The current use case for this is sending notifications when content has been re-categorised (re-tagged), the significance being that the content will appear in a high profile collection of finder results.

[See RFC here](https://github.com/alphagov/govuk-rfcs/blob/2cc32ae534d0f30f9702401a31ccd69f73bc4706/rfc-102-add-notification-workflow.md) and [Publishing API PR here](https://github.com/alphagov/publishing-api/pull/1482)