### PR TITLE
Fix working with end-to-end tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.6.3
+RUN gem install foreman
 
 ENV RABBITMQ_HOSTS rabbitmq
 ENV RABBITMQ_VHOST /
@@ -16,4 +17,4 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-CMD bin/email_alert_service
+CMD foreman run major-change-queue-consumer

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject(rubyLintDiff: false)
+  govuk.buildProject(publishingE2ETests: true, rubyLintDiff: false)
 }


### PR DESCRIPTION
Trello: https://trello.com/c/odtNdsay/574-e2e-tests-failing-since-monday-morning

This adds a few changes that aim to resolve problems running the end-to-end tests.

This depends on https://github.com/alphagov/publishing-e2e-tests/pull/326 and the end-to-end test result here is based on that.

This firstly makes this repo run the end-to-end tests as part of it's build so that it is harder for this app to break the build. This is a slightly annoying situation as the end-to-end tests aren't actually being tested but apps (Content Tagger) do break without them.

This then adds a rake task to create the RabbitMQ queues that are used by this app. I'm not sure whether these were used / worked before. 

Finally this updates the dockerfile to reflect the deprecation of the bin/email_alert_service command.