### PR TITLE
Remove deprecated script and configuration

### DIFF
--- a/bin/email_alert_service
+++ b/bin/email_alert_service
@@ -1,4 +1,0 @@
-#!/bin/bash
-bundle exec rake message_queues:major_change_consumer &
-bundle exec rake message_queues:unpublishing_consumer &
-wait

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -1,11 +1,4 @@
 defaults: &defaults
-  amqp:
-    hosts: [localhost]
-    port: 5672
-    vhost: /
-    user: email_alert_service
-    pass: email_alert_service
-    recover_from_connection_close: true
 
 development:
   <<: *defaults
@@ -20,9 +13,6 @@ development:
 
 test:
   <<: *defaults
-  amqp:
-    user: email_alert_service_test
-    pass: email_alert_service_test
   exchange: email_alert_service_published_documents_test_exchange
   queues:
     - processor: major_change_message_processor
@@ -34,15 +24,6 @@ test:
 
 production:
   <<: *defaults
-  amqp:
-    hosts:
-      <% hosts = ENV['RABBITMQ_HOSTS'] || 'localhost' %>
-      <% hosts.split(",").each do |host| %>
-      - <%= host %>
-      <% end %>
-    user: <%= ENV['RABBITMQ_USER'] %>
-    pass: <%= ENV['RABBITMQ_PASSWORD'] %>
-    recover_from_connection_close: true
   exchange: <%= ENV['RABBITMQ_EXCHANGE'] || 'published_documents' %>
   queues:
     - processor: major_change_message_processor


### PR DESCRIPTION
As the email-alert-service now uses the govuk_message_queue_consumer gem
these are now deprecated and may be removed.

https://trello.com/c/eJZ7G7Fb/1018-remove-start-up-script-and-rabbitmq-config-from-email-alert-service