### PR TITLE
Use create_content_change instead of send_alert

### DIFF
--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -13,7 +13,7 @@ class EmailAlert
     logger.info "Received major change notification for #{document['title']}, with details #{document['details']}"
     lock_handler.with_lock_unless_done do
       begin
-        Services.email_api_client.send_alert(format_for_email_api, govuk_request_id: document['govuk_request_id'])
+        Services.email_api_client.create_content_change(format_for_email_api, govuk_request_id: document['govuk_request_id'])
       rescue GdsApi::HTTPConflict
         logger.info "email-alert-api returned conflict for #{document['content_id']}, #{document['base_path']}, #{document['public_updated_at']}"
       rescue GdsApi::HTTPUnprocessableEntity

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EmailAlert do
   end
 
   let(:logger) { double(:logger, info: nil) }
-  let(:alert_api) { double(:alert_api, send_alert: nil) }
+  let(:alert_api) { double(:alert_api, create_content_change: nil) }
   let(:email_alert) { EmailAlert.new(document, logger) }
   let(:fake_lock_handler) { FakeLockHandler.new }
 
@@ -66,14 +66,14 @@ RSpec.describe EmailAlert do
     it "sends an alert to the Email Alert API" do
       email_alert.trigger
 
-      expect(alert_api).to have_received(:send_alert).with(
+      expect(alert_api).to have_received(:create_content_change).with(
         hash_including("content_id" => content_id),
         govuk_request_id: govuk_request_id
       )
     end
 
     it "logs if it receives a conflict" do
-      allow(alert_api).to receive(:send_alert).and_raise(GdsApi::HTTPConflict.new(409))
+      allow(alert_api).to receive(:create_content_change).and_raise(GdsApi::HTTPConflict.new(409))
       email_alert.trigger
 
       expect(logger).to have_received(:info).with(
@@ -82,7 +82,7 @@ RSpec.describe EmailAlert do
     end
 
     it "logs if it receives an unprocessable entity" do
-      allow(alert_api).to receive(:send_alert).and_raise(GdsApi::HTTPUnprocessableEntity.new(422))
+      allow(alert_api).to receive(:create_content_change).and_raise(GdsApi::HTTPUnprocessableEntity.new(422))
       email_alert.trigger
 
       expect(logger).to have_received(:info).with(


### PR DESCRIPTION
This method was recently renamed in the [latest version of GDS API Adapters](https://github.com/alphagov/gds-api-adapters/pull/948).

[Trello Card](https://trello.com/c/5rtAmAjc/54-finish-the-messages-endpoint-work-in-email-alert-api)