### PR TITLE
Rescope email alerts for the service standard

### DIFF
--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -46,12 +46,11 @@ protected
 
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
-    document_type = document.fetch("document_type")
 
-    contains_supported_attribute?(document_links)
-      || contains_supported_attribute?(document_tags)
-      || allowed_document_type?(document_type)
-      || has_relevant_document_supertype?(document)
+    contains_supported_attribute?(document_links) ||
+      contains_supported_attribute?(document_tags) ||
+      links_to_singleton_page?(document_links) ||
+      has_relevant_document_supertype?(document)
   end
 
   def contains_supported_attribute?(tags_hash)
@@ -99,10 +98,9 @@ protected
     %w[coming_soon special_route].include?(document_type)
   end
 
-  def allowed_document_type?(document_type)
-    # It's possible to subscribe to these without any other filtering, so we
-    # should always let them through
-    document_type == "service_manual_guide"
+  def links_to_singleton_page?(document_links)
+    # These documents link to the single-instance of service_manual_service_standard
+    document_links["parent"] == %w[00f693d4-866a-4fe6-a8d6-09cd7db8980b]
   end
 
   def has_relevant_document_supertype?(document)

--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -41,17 +41,16 @@ protected
   end
 
   def email_alerts_supported?(document)
-    blacklisted = blacklisted_publishing_app?(document["publishing_app"]) \
-      || blacklisted_document_type?(document["document_type"])
-    return false if blacklisted
+    return false if blocked_publishing_app?(document["publishing_app"]) ||
+      blocked_document_type?(document["document_type"])
 
     document_tags = document.fetch("details", {}).fetch("tags", {})
     document_links = document.fetch("links", {})
     document_type = document.fetch("document_type")
 
-    contains_supported_attribute?(document_links) \
-      || contains_supported_attribute?(document_tags) \
-      || whitelisted_document_type?(document_type) \
+    contains_supported_attribute?(document_links)
+      || contains_supported_attribute?(document_tags)
+      || allowed_document_type?(document_type)
       || has_relevant_document_supertype?(document)
   end
 
@@ -81,7 +80,7 @@ protected
     end
   end
 
-  def blacklisted_publishing_app?(publishing_app)
+  def blocked_publishing_app?(publishing_app)
     # These publishing apps make direct calls to email-alert-api to send their
     # emails, so we need to avoid sending duplicate emails when they come
     # through on the queue:
@@ -94,13 +93,13 @@ protected
     false
   end
 
-  def blacklisted_document_type?(document_type)
+  def blocked_document_type?(document_type)
     # These are documents that don't make sense to email someone about as they
     # are not useful to an end user.
     %w[coming_soon special_route].include?(document_type)
   end
 
-  def whitelisted_document_type?(document_type)
+  def allowed_document_type?(document_type)
     # It's possible to subscribe to these without any other filtering, so we
     # should always let them through
     document_type == "service_manual_guide"

--- a/spec/models/major_change_message_processor_spec.rb
+++ b/spec/models/major_change_message_processor_spec.rb
@@ -201,11 +201,10 @@ RSpec.describe MajorChangeMessageProcessor do
       end
     end
 
-    context "no links or tags but allowed document type" do
+    context "has a link to the service standard" do
       before do
         good_document["details"] = { "change_history" => change_history }
-        good_document["links"] = { "parent" => %w[parent-topic-uuid] }
-        good_document["document_type"] = "service_manual_guide"
+        good_document["links"] = { "parent" => %w[00f693d4-866a-4fe6-a8d6-09cd7db8980b] }
       end
 
       it "still acknowledges and triggers the email" do

--- a/spec/models/major_change_message_processor_spec.rb
+++ b/spec/models/major_change_message_processor_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe MajorChangeMessageProcessor do
       end
     end
 
-    context "no links or tags but of whitelisted document type" do
+    context "no links or tags but allowed document type" do
       before do
         good_document["details"] = { "change_history" => change_history }
         good_document["links"] = { "parent" => %w[parent-topic-uuid] }
@@ -216,7 +216,7 @@ RSpec.describe MajorChangeMessageProcessor do
       end
     end
 
-    context "has links but is from a blacklisted publishing application" do
+    context "has links but is from a blocked publishing application" do
       before do
         good_document["details"] = { "change_history" => change_history }
         good_document["links"] = { "taxons" => %w[taxon-uuid] }
@@ -231,7 +231,7 @@ RSpec.describe MajorChangeMessageProcessor do
       end
     end
 
-    context "has links but is from a blacklisted document type" do
+    context "has links but is from a blocked document type" do
       before do
         good_document["details"] = { "change_history" => change_history }
         good_document["links"] = { "taxons" => %w[taxon-uuid] }


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-not-ready-to-start-deprecate-and-remove-legacy-email-signup-pages

Previously we added a rule that allowed for alerts to be triggered when a
service_manual_guide was published, in order to accommodate the
subscriptions to the service standard, which is a singleton index page for
several guides [1]. Allowing based on document type is not ideal because
it's unclear what subscriptions this might trigger updates for. This
replaces the original approach by fully articulating the conditions for
which an alert should trigger.

[1]:
https://github.com/alphagov/email-alert-service/commit/1db3c0e34896eae8b7adfa938e11c509fd35e591