### PR TITLE
Remove constraints from dependencies in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
-gem "bunny", "~> 2.15"
-gem "gds-api-adapters", "~> 67.0"
-gem "govuk_app_config", "~> 2.3"
-gem "govuk_message_queue_consumer", "~> 3.5"
-gem "plek", "~> 4.0"
+gem "bunny"
+gem "gds-api-adapters"
+gem "govuk_app_config"
+gem "govuk_message_queue_consumer"
+gem "plek"
 gem "rake"
-gem "redis", "~> 4.2"
-gem "redis-namespace", "~> 1.7"
-gem "tzinfo", "~> 1.2"
-gem "tzinfo-data", "~> 1.2020"
+gem "redis"
+gem "redis-namespace"
+gem "tzinfo"
+gem "tzinfo-data"
 
 group :development, :test do
   gem "pry-byebug"
@@ -17,10 +17,10 @@ group :development, :test do
 end
 
 group :test do
-  gem "govuk_schemas", "~> 4.1"
-  gem "rspec-core", "~> 3.9"
-  gem "rspec-expectations", "~> 3.9"
-  gem "rspec-mocks", "~> 3.9"
+  gem "govuk_schemas"
+  gem "rspec-core"
+  gem "rspec-expectations"
+  gem "rspec-mocks"
   gem "simplecov"
-  gem "webmock", "~> 3.8"
+  gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,24 +153,24 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bunny (~> 2.15)
-  gds-api-adapters (~> 67.0)
-  govuk_app_config (~> 2.3)
-  govuk_message_queue_consumer (~> 3.5)
-  govuk_schemas (~> 4.1)
-  plek (~> 4.0)
+  bunny
+  gds-api-adapters
+  govuk_app_config
+  govuk_message_queue_consumer
+  govuk_schemas
+  plek
   pry-byebug
   rake
-  redis (~> 4.2)
-  redis-namespace (~> 1.7)
-  rspec-core (~> 3.9)
-  rspec-expectations (~> 3.9)
-  rspec-mocks (~> 3.9)
+  redis
+  redis-namespace
+  rspec-core
+  rspec-expectations
+  rspec-mocks
   rubocop-govuk
   simplecov
-  tzinfo (~> 1.2)
-  tzinfo-data (~> 1.2020)
-  webmock (~> 3.8)
+  tzinfo
+  tzinfo-data
+  webmock
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Use the Gemfile.lock to manage the versions instead which should make it easier to upgrade as it allows bundler a wider set of versions to resolve the dependencies.

(Part of the work to upgrade to Ruby 2.7.1 but no other changes were necessary)