### PR TITLE
Remove custom JSON log formatting

### DIFF
--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -28,13 +28,7 @@ module EmailAlertService
     end
 
     def logger
-      @logger ||= begin
-        formatter = proc do |_severity, datetime, _progname, msg|
-          JSON.dump("@timestamp" => datetime.iso8601, message: msg) + "\n"
-        end
-
-        Logger.new(STDOUT, formatter: formatter)
-      end
+      @logger ||= Logger.new(STDOUT)
     end
 
   private


### PR DESCRIPTION
https://trello.com/c/F8uizllI/537-fix-kibana-not-ingesting-email-alert-service-logs

This is no longer necessary since non-JSON logs are now accepted [1].

[1]: https://github.com/alphagov/govuk-puppet/pull/10759