### PR TITLE
Remove need for REDIS_HOST and REDIS_PORT env vars

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -17,8 +17,5 @@ end
 
 EmailAlertService.services(
   :redis,
-  Redis::Namespace.new(
-    EmailAlertService.config.redis_config[:namespace],
-    redis: Redis.new(EmailAlertService.config.redis_config),
-  ),
+  Redis::Namespace.new("email-alert-service", redis: Redis.new),
 )

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,0 @@
-host: <%= ENV['REDIS_HOST'] || '127.0.0.1' %>
-port: 6379
-namespace: email-alert-service

--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -23,10 +23,6 @@ module EmailAlertService
       @rabbitmq ||= symbolize_keys(environment_config).freeze
     end
 
-    def redis_config
-      symbolize_keys(YAML.safe_load(ERB.new(File.read(app_root + "config/redis.yml")).result, [], [], true))
-    end
-
     def logger
       @logger ||= Logger.new(STDOUT)
     end


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This is one of the few GOV.UK projects that uses this old approach to
configuring Redis - whereas most of the other ones use the approach
supported natively by the Redis gem [1] of using REDIS_URL. Removing
this will allow us to remove the need for REDIS_HOST and REDIS_PORT env
vars in our architecture and also allows this code to be simplified.

[1]: https://github.com/redis/redis-rb