### PR TITLE
Remove stray instance of unpublishing task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
 major-change-queue-consumer: bundle exec rake message_queues:major_change_consumer
-unpublishing-queue-consumer: bundle exec rake message_queues:unpublishing_consumer


### PR DESCRIPTION
https://trello.com/c/fbmVmwG3/666-remove-the-undocumented-taxon-unpublish-redirect-feature

This was missed in [1].

[1]: https://github.com/alphagov/email-alert-service/pull/430