### PR TITLE
Revise tech docs in README to favour GOV.UK Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,32 @@ This is a message queue consumer that triggers email alerts when documents are p
 
 ## Technical documentation
 
-Messages are read from the `published_documents` exchange which carries documents
-published from all publishing applications via the content-store.
+You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-docker) to run the application and its tests with all the necessary dependencies. Follow [the usage instructions](https://github.com/alphagov/govuk-docker#usage) to get started.
 
-When the service detects a published document which was tagged to one or more
-topics, it builds an email message, and passes it to email-alert-api.
+**Use GOV.UK Docker to run any commands that follow.**
 
-### Dependencies
-
-- redis
-
-### Running the application
+### Before running the app
 
 The email-alert-service uses the [govuk_message_queue_consumer](https://github.com/alphagov/govuk_message_queue_consumer)
 to connect to a message queue on the `published_documents` exchange.
 
 There is a rake task to create the queue for this exchange:
 
-`bundle exec rake message_queues:create_queues`
+```
+bundle exec rake message_queues:create_queues
+```
 
 There is a rake task to start a processor to consume from the queue:
 
-`bundle exec rake message_queues:major_change_consumer`
+```
+bundle exec rake message_queues:major_change_consumer
+```
 
 ### Running the test suite
 
-`bundle exec rspec`
+```
+bundle exec rake
+```
 
 ## Licence
 


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This follows the pattern established in [1].

[1]: https://github.com/alphagov/content-publisher/pull/2257