### PR TITLE
Add Redis check to rake task

### DIFF
--- a/lib/tasks/message_queues.rake
+++ b/lib/tasks/message_queues.rake
@@ -23,6 +23,7 @@ namespace :message_queues do
     logger.info "Bound to exchange #{exchange_name} on major change queue"
     begin
       GovukError.configure
+      EmailAlertService.services(:redis)
       GovukMessageQueueConsumer::Consumer.new(
         queue_name: "email_alert_service",
         processor: MajorChangeMessageProcessor.new(logger),


### PR DESCRIPTION
As part of the work to enable continuous deployment of all GOV.UK
apps we need to add a check for connectivity to Redis. Since Email
Alert Service is not a web app, this check had to be added to the rake
task that is called at startup time. This commit adds a call to the
Redis service that will throw an error if it does not exist.

https://trello.com/c/AGNZWDFJ/2693-enable-continuous-deployment-for-email-alert-service-3