### PR TITLE
Fix email-api uses slugs not uuids called id

### DIFF
--- a/email_alert_service/models/unpublishing_alert.rb
+++ b/email_alert_service/models/unpublishing_alert.rb
@@ -38,7 +38,7 @@ private
 
   def get_subscriber_list
     @subscriber_list = Services.email_api_client.find_subscriber_list(content_id: document.fetch("content_id"))
-    @subscriber_list_id = @subscriber_list.to_h.fetch("subscriber_list").fetch("id")
+    @subscriber_list_id = @subscriber_list.to_h.fetch("subscriber_list").fetch("slug")
   rescue GdsApi::HTTPNotFound
     logger.info "subscriber list not found for content id #{document['content_id']}"
     nil

--- a/spec/models/unpublishing_alert_spec.rb
+++ b/spec/models/unpublishing_alert_spec.rb
@@ -59,11 +59,11 @@ RSpec.describe UnpublishingAlert do
   let(:logger) { double(:logger, info: nil) }
   let(:unpublishing_alert) { UnpublishingAlert.new(document, logger, unpublishing_scenario) }
   let(:fake_lock_handler) { fake_lock_handler_class.new }
-  let(:subscriber_list_uuid) { SecureRandom.uuid }
+  let(:subscriber_list_slug) { "i_am_a_subscriber_list_slug" }
   let(:subscriber_list_response) do
     {
       "subscriber_list" => {
-        "id" => subscriber_list_uuid,
+        "slug" => subscriber_list_slug,
         "title" => "Subscriber List Title",
       },
     }
@@ -90,7 +90,7 @@ RSpec.describe UnpublishingAlert do
 
         expect(alert_api).to have_received(:bulk_unsubscribe).with(
           {
-            "subscriber_list_id" => subscriber_list_uuid,
+            "subscriber_list_id" => subscriber_list_slug,
             "body" => email_markdown.strip,
             "sender_message_id" => sender_message_id,
           }.to_json,


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
