### PR TITLE
Log base path for unpublishing events

### DIFF
--- a/email_alert_service/models/unpublishing_alert.rb
+++ b/email_alert_service/models/unpublishing_alert.rb
@@ -9,7 +9,7 @@ class UnpublishingAlert
   end
 
   def trigger
-    logger.info "Received unsubscription notification for #{document['title']}, unpublishing_scenario: #{unpublishing_scenario}, full payload: #{document}"
+    logger.info "Received unsubscription notification for #{document['base_path']}, unpublishing_scenario: #{unpublishing_scenario}, full payload: #{document}"
     get_subscriber_list
     bulk_unsubscribe if subscriber_list_id
   end

--- a/spec/models/unpublishing_alert_spec.rb
+++ b/spec/models/unpublishing_alert_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe UnpublishingAlert do
         unpublishing_alert.trigger
 
         expect(logger).to have_received(:info).with(
-          "Received unsubscription notification for #{document['title']}, unpublishing_scenario: #{unpublishing_scenario}, full payload: #{document}",
+          "Received unsubscription notification for #{document['base_path']}, unpublishing_scenario: #{unpublishing_scenario}, full payload: #{document}",
         )
       end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

The `title` key isn't in the message payload, so log `base_path` instead 
as that's likely to be most useful if debugging in the future.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
