### PR TITLE
Correctly parse public_updated_at timestamps

### DIFF
--- a/email_alert_service/presenters/unpublishing_message_presenter.rb
+++ b/email_alert_service/presenters/unpublishing_message_presenter.rb
@@ -19,7 +19,7 @@ private
   attr_reader :unpublishing_scenario, :document
 
   def formatted_time
-    Time.new(document["public_updated_at"]).strftime(EMAIL_DATE_FORMAT)
+    Time.iso8601(document["public_updated_at"]).strftime(EMAIL_DATE_FORMAT)
   end
 
   def unpublishing_scenario_note

--- a/spec/models/unpublishing_alert_spec.rb
+++ b/spec/models/unpublishing_alert_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe UnpublishingAlert do
   include LockHandlerTestHelpers
   let(:content_id) { SecureRandom.uuid }
   let(:govuk_request_id) { "govuk_request_id" }
-  let(:public_updated_at) { updated_now.iso8601 }
+  let(:time) { Time.now }
+  let(:public_updated_at) { time.iso8601 }
   let(:sender_message_id) { UUIDv5.call(content_id, public_updated_at) }
-  let(:formatted_time) { Time.new(public_updated_at).strftime(UnpublishingMessagePresenter::EMAIL_DATE_FORMAT) }
+  let(:formatted_time) { time.strftime(UnpublishingMessagePresenter::EMAIL_DATE_FORMAT) }
 
   let(:published_in_error_payload) do
     {

--- a/spec/presenters/unpublishing_message_presenter_spec.rb
+++ b/spec/presenters/unpublishing_message_presenter_spec.rb
@@ -3,8 +3,9 @@ require "spec_helper"
 RSpec.describe UnpublishingMessagePresenter do
   let(:content_id) { SecureRandom.uuid }
   let(:govuk_request_id) { SecureRandom.uuid }
-  let(:public_updated_at) { Time.now.iso8601 }
-  let(:formatted_time) { Time.new(public_updated_at).strftime(UnpublishingMessagePresenter::EMAIL_DATE_FORMAT) }
+  let(:time) { Time.now }
+  let(:public_updated_at) { time.iso8601 }
+  let(:formatted_time) { time.strftime(UnpublishingMessagePresenter::EMAIL_DATE_FORMAT) }
   let(:alternative_path) { nil }
   let(:website_domain) { "https://www.test.gov.uk" }
   let(:presenter) { UnpublishingMessagePresenter.new(unpublishing_scenario, document) }


### PR DESCRIPTION
Because we were going via `Time.now` instead of `Time.iso8601`, we
were losing information and ending up with midnight on the 1st of
January (this year).

I've updated the tests to go more directly from a `Time` object to the
formatted time, which catches this, and then fixed the code.

---

[Trello card](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)
