### PR TITLE
Update subscriber list titles on major / minor publication events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
-    gds-api-adapters (78.1.0)
+    gds-api-adapters (79.0.0)
       addressable
       link_header
       null_logger

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
 major-change-queue-consumer: bundle exec rake message_queues:major_change_consumer
 unpublishing-queue-consumer: bundle exec rake message_queues:unpublishing_consumer
+subscriber-list-details-update-major-consumer: bundle exec rake message_queues:subscriber_list_details_update_major_consumer
+subscriber-list-details-update-minor-consumer: bundle exec rake message_queues:subscriber_list_details_update_minor_consumer

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -10,6 +10,12 @@ development:
     - processor: email_unpublishing_processor
       name: email_unpublishing
       routing_key: '*.unpublish.#'
+    - processor: subscriber_list_details_update_major_processor
+      name: subscriber_list_details_update_major
+      routing_key: "*.major.#"
+    - processor: subscriber_list_details_update_minor_processor
+      name: subscriber_list_details_update_minor
+      routing_key: "*.minor.#"
 
 test:
   <<: *defaults
@@ -21,6 +27,12 @@ test:
     - processor: email_unpublishing_processor
       name: email_unpublishing
       routing_key: "*.unpublish.#"
+    - processor: subscriber_list_details_update_major_processor
+      name: subscriber_list_details_update_major
+      routing_key: "*.major.#"
+    - processor: subscriber_list_details_update_minor_processor
+      name: subscriber_list_details_update_minor
+      routing_key: "*.minor.#"
 
 production:
   <<: *defaults
@@ -32,4 +44,10 @@ production:
     - processor: email_unpublishing_processor
       name: email_unpublishing
       routing_key: "*.unpublish.#"
+    - processor: subscriber_list_details_update_major_processor
+      name: subscriber_list_details_update_major
+      routing_key: "*.major.#"
+    - processor: subscriber_list_details_update_minor_processor
+      name: subscriber_list_details_update_minor
+      routing_key: "*.minor.#"
 

--- a/email_alert_service/models/email_unpublishing_processor.rb
+++ b/email_alert_service/models/email_unpublishing_processor.rb
@@ -63,8 +63,4 @@ private
   def was_published_in_error?
     document["document_type"] == "gone"
   end
-
-  def has_content_id?(document)
-    has_non_blank_value_for_key?(document: document, key: "content_id")
-  end
 end

--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -118,10 +118,6 @@ private
       relevant_supertype.call(document["email_document_supertype"])
   end
 
-  def has_title?(document)
-    has_non_blank_value_for_key?(document: document, key: "title")
-  end
-
   def has_change_note?(document)
     note = ChangeHistory.new(
       history: document.dig("details", "change_history"),

--- a/email_alert_service/models/message_processor.rb
+++ b/email_alert_service/models/message_processor.rb
@@ -43,4 +43,12 @@ protected
 
     document["locale"] == "en"
   end
+
+  def has_content_id?(document)
+    has_non_blank_value_for_key?(document: document, key: "content_id")
+  end
+
+  def has_title?(document)
+    has_non_blank_value_for_key?(document: document, key: "title")
+  end
 end

--- a/email_alert_service/models/subscriber_list_details_update_processor.rb
+++ b/email_alert_service/models/subscriber_list_details_update_processor.rb
@@ -1,0 +1,35 @@
+require_relative("./message_processor")
+
+class SubscriberListDetailsUpdateProcessor < MessageProcessor
+protected
+
+  def process_message(message)
+    document = message.payload
+
+    unless has_content_id?(document)
+      @logger.info "not triggering subscriber list update for a document with no content_id: #{document}"
+      return
+    end
+
+    unless has_title?(document)
+      @logger.info "not triggering subscriber list update for a document with no title: #{document}"
+      return
+    end
+
+    unless is_english?(document)
+      @logger.info "not triggering subscriber list update for a non-english document #{document['title']}: locale #{document['locale']}"
+      return
+    end
+
+    @logger.info "triggering subscriber list update for document: #{document['title']}"
+    trigger_subscriber_list_update(document)
+  end
+
+private
+
+  attr_reader :logger
+
+  def trigger_subscriber_list_update(document)
+    UpdateSubscriberList.new(document, logger).trigger
+  end
+end

--- a/email_alert_service/models/unpublishing_alert.rb
+++ b/email_alert_service/models/unpublishing_alert.rb
@@ -1,7 +1,10 @@
 require "gds_api/email_alert_api"
 require "lib/uuid_v5"
+require "lib/email_alert_api_helpers"
 
 class UnpublishingAlert
+  include EmailAlertApiHelpers
+
   def initialize(document, logger, unpublishing_scenario)
     @document = document
     @logger = logger
@@ -33,14 +36,6 @@ private
     rescue GdsApi::HTTPNotFound
       logger.info "email-alert-api returned not_found for #{document['content_id']}, #{document['base_path']}, #{document['public_updated_at']}"
     end
-  end
-
-  def get_subscriber_list
-    @subscriber_list = Services.email_api_client.find_subscriber_list(content_id: document.fetch("content_id"))
-    @subscriber_list_slug = @subscriber_list.to_h.fetch("subscriber_list").fetch("slug")
-  rescue GdsApi::HTTPNotFound
-    logger.info "subscriber list not found for content id #{document['content_id']}"
-    nil
   end
 
   def unpublishing_message

--- a/email_alert_service/models/update_subscriber_list.rb
+++ b/email_alert_service/models/update_subscriber_list.rb
@@ -1,0 +1,51 @@
+class UpdateSubscriberList
+  def initialize(document, logger)
+    @document = document
+    @logger = logger
+  end
+
+  def trigger
+    get_subscriber_list
+    return unless subscriber_list_slug
+
+    if parameters_need_updating?
+      logger.info "Updating subscriber list: #{subscriber_list_slug}, with: #{updateable_parameters}"
+      update_subscriber_list_details
+    else
+      logger.info "No update needed to subscriber list: #{subscriber_list_slug}"
+    end
+  end
+
+private
+
+  attr_reader :document, :logger, :subscriber_list, :subscriber_list_slug
+
+  def update_subscriber_list_details
+    Services.email_api_client.update_subscriber_list_details(
+      slug: subscriber_list_slug,
+      params: updateable_parameters,
+    )
+  rescue GdsApi::HTTPUnprocessableEntity
+    logger.info "email-alert-api returned unproessable entity updating subscriber list: #{subscriber_list_slug}, with: #{updateable_parameters}"
+  rescue GdsApi::HTTPNotFound
+    logger.info "email-alert-api cannot find subscriber list with slug #{subscriber_list_slug}"
+  end
+
+  def get_subscriber_list
+    @subscriber_list = Services.email_api_client.find_subscriber_list(content_id: document.fetch("content_id"))
+                                               .to_h.fetch("subscriber_list")
+    @subscriber_list_slug = @subscriber_list.fetch("slug")
+  rescue GdsApi::HTTPNotFound
+    logger.info "subscriber list not found for content id #{document['content_id']}"
+  end
+
+  def updateable_parameters
+    {
+      "title" => document["title"],
+    }
+  end
+
+  def parameters_need_updating?
+    subscriber_list["title"] != document["title"]
+  end
+end

--- a/email_alert_service/models/update_subscriber_list.rb
+++ b/email_alert_service/models/update_subscriber_list.rb
@@ -1,4 +1,8 @@
+require "lib/email_alert_api_helpers"
+
 class UpdateSubscriberList
+  include EmailAlertApiHelpers
+
   def initialize(document, logger)
     @document = document
     @logger = logger
@@ -29,14 +33,6 @@ private
     logger.info "email-alert-api returned unproessable entity updating subscriber list: #{subscriber_list_slug}, with: #{updateable_parameters}"
   rescue GdsApi::HTTPNotFound
     logger.info "email-alert-api cannot find subscriber list with slug #{subscriber_list_slug}"
-  end
-
-  def get_subscriber_list
-    @subscriber_list = Services.email_api_client.find_subscriber_list(content_id: document.fetch("content_id"))
-                                               .to_h.fetch("subscriber_list")
-    @subscriber_list_slug = @subscriber_list.fetch("slug")
-  rescue GdsApi::HTTPNotFound
-    logger.info "subscriber list not found for content id #{document['content_id']}"
   end
 
   def updateable_parameters

--- a/lib/email_alert_api_helpers.rb
+++ b/lib/email_alert_api_helpers.rb
@@ -1,0 +1,9 @@
+module EmailAlertApiHelpers
+  def get_subscriber_list
+    @subscriber_list = Services.email_api_client.find_subscriber_list(content_id: document.fetch("content_id"))
+                                               .to_h.fetch("subscriber_list")
+    @subscriber_list_slug = @subscriber_list.fetch("slug")
+  rescue GdsApi::HTTPNotFound
+    logger.info "subscriber list not found for content id #{document['content_id']}"
+  end
+end

--- a/lib/tasks/message_queues.rake
+++ b/lib/tasks/message_queues.rake
@@ -57,4 +57,44 @@ namespace :message_queues do
       exit 1
     end
   end
+
+  desc "Run workers to consume subscriber list updates for major change messages from rabbitmq"
+  task :subscriber_list_details_update_major_consumer do
+    logger.info "Bound to exchange #{exchange_name} on major change"
+    begin
+      GovukError.configure
+      EmailAlertService.services(:redis)
+      GovukMessageQueueConsumer::Consumer.new(
+        queue_name: "subscriber_list_details_major_update",
+        processor: SubscriberListDetailsUpdateProcessor.new(logger),
+        logger: logger,
+      ).run
+    rescue SignalException => e
+      logger.info "Signal Exception: #{e}"
+      exit 1
+    rescue StandardError => e
+      logger.info "Error: #{e}"
+      exit 1
+    end
+  end
+
+  desc "Run workers to consume subscriber list updates for minor change messages from rabbitmq"
+  task :subscriber_list_details_update_minor_consumer do
+    logger.info "Bound to exchange #{exchange_name} on minor change"
+    begin
+      GovukError.configure
+      EmailAlertService.services(:redis)
+      GovukMessageQueueConsumer::Consumer.new(
+        queue_name: "subscriber_list_details_minor_update",
+        processor: SubscriberListDetailsUpdateProcessor.new(logger),
+        logger: logger,
+      ).run
+    rescue SignalException => e
+      logger.info "Signal Exception: #{e}"
+      exit 1
+    rescue StandardError => e
+      logger.info "Error: #{e}"
+      exit 1
+    end
+  end
 end

--- a/spec/lib/email_alert_api_helpers_spec.rb
+++ b/spec/lib/email_alert_api_helpers_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+RSpec.describe EmailAlertApiHelpers do
+  describe "#get_subscriber_list" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:document) { { "content_id" => content_id } }
+    let(:subscriber_list_slug) { "slug" }
+
+    let(:subscriber_list_attributes) do
+      {
+        "id" => "447135c3-07d6-4c3a-8a3b-efa49ef70e52",
+        "active_subscriptions_count" => 42,
+        "content_id" => content_id,
+        "slug" => subscriber_list_slug,
+        "title" => "title",
+      }
+    end
+
+    let(:logger) { double(:logger, info: nil) }
+    let(:helper_class) do
+      Class.new do
+        include EmailAlertApiHelpers
+        attr_reader :document, :logger
+
+        def initialize(document, logger)
+          @document = document
+          @logger = logger
+        end
+      end
+    end
+
+    let(:helper) { helper_class.new(document, logger) }
+
+    context "given a document with content ID matching a subscriber list" do
+      before { stub_email_alert_api_has_subscriber_list(subscriber_list_attributes) }
+
+      it "creates a subscriber_list instance varaible containing subscriber_list data from email-alert-api" do
+        helper.get_subscriber_list
+        expect(helper.instance_variable_get("@subscriber_list")).to eq(subscriber_list_attributes)
+      end
+
+      it "creates a @subscriber_list_slug instance varaible containing subscriber_list data from email-alert-api" do
+        helper.get_subscriber_list
+        expect(helper.instance_variable_get("@subscriber_list_slug")).to eq(subscriber_list_slug)
+      end
+    end
+
+    context "given a document with a content ID that does not match a subscriber list" do
+      before { stub_email_alert_api_does_not_have_subscriber_list(subscriber_list_attributes) }
+
+      it "does not set a @subscriber_list instance variable" do
+        helper.get_subscriber_list
+        expect(helper.instance_variable_defined?("@subscriber_list")).to be false
+      end
+
+      it "does not set a @subscriber_list_slug instance variable" do
+        helper.get_subscriber_list
+        expect(helper.instance_variable_defined?("@subscriber_list_slug")).to be false
+      end
+
+      it "logs that the subscriber list was not found" do
+        helper.get_subscriber_list
+        expect(logger).to have_received(:info).with(
+          "subscriber list not found for content id #{document['content_id']}",
+        )
+      end
+    end
+  end
+end

--- a/spec/models/subscriber_list_details_update_processor_spec.rb
+++ b/spec/models/subscriber_list_details_update_processor_spec.rb
@@ -1,0 +1,98 @@
+require "spec_helper"
+
+RSpec.describe SubscriberListDetailsUpdateProcessor do
+  include MessageProcessorHelpers
+
+  let(:logger) { double(:logger, info: nil) }
+
+  let(:message) do
+    double(
+      :message_queue_consumer_message,
+      ack: nil,
+      discard: nil,
+      retry: nil,
+      payload: document,
+    )
+  end
+
+  let(:processor) { SubscriberListDetailsUpdateProcessor.new(logger) }
+
+  let(:content_id) { SecureRandom.uuid }
+
+  let(:document_title) { "Example title" }
+  let(:subscriber_list_title) { "An old outdated title" }
+  let(:subscriber_list_slug) { "subscriber_list_slug" }
+
+  let(:document) do
+    {
+      "base_path" => "path/to-doc",
+      "content_id" => content_id,
+      "title" => document_title,
+      "locale" => "en",
+    }
+  end
+
+  let(:subscriber_list_attributes) do
+    {
+      "content_id" => content_id,
+      "slug" => subscriber_list_slug,
+      "title" => subscriber_list_title,
+    }
+  end
+
+  let(:updateable_parameters) { { "title" => document_title } }
+
+  describe "#process" do
+    it "acknowledges and triggers the update for a correctly formatted document" do
+      stub_email_alert_api_has_subscriber_list(subscriber_list_attributes)
+      stub_update_subscriber_list_details(slug: subscriber_list_slug, params: updateable_parameters)
+
+      processor.process(message)
+
+      message_acknowledged
+      expect(logger).to have_received(:info).with(
+        "triggering subscriber list update for document: #{document_title}",
+      )
+    end
+
+    context "document is not in English" do
+      let(:locale) { "fr" }
+      before { document["locale"] = locale }
+
+      it "acknowledges but doesn't trigger the update" do
+        processor.process(message)
+
+        message_acknowledged
+        expect(logger).to have_received(:info).with(
+          "not triggering subscriber list update for a non-english document #{document_title}: locale #{locale}",
+        )
+      end
+    end
+
+    context "document has no content_id" do
+      before { document.delete("content_id") }
+
+      it "acknowledges but doesn't trigger the update" do
+        processor.process(message)
+
+        message_acknowledged
+        expect(logger).to have_received(:info).with(
+          "not triggering subscriber list update for a document with no content_id: #{document}",
+        )
+      end
+    end
+
+    context "document has no title" do
+      before { document.delete("title") }
+
+      it "acknowledges but doesn't trigger the update" do
+        processor.process(message)
+
+        message_acknowledged
+        expect(logger).to have_received(:info).with(
+          "not triggering subscriber list update for a document with no title: #{document}",
+        )
+      end
+    end
+  end
+end

--- a/spec/models/update_subscriber_list_spec.rb
+++ b/spec/models/update_subscriber_list_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+RSpec.describe UpdateSubscriberList do
+  let(:content_id) { SecureRandom.uuid }
+  let(:document_title) { "Example Title" }
+  let(:document) do
+    {
+      "base_path" => "/foo",
+      "content_id" => content_id,
+      "title" => document_title,
+    }
+  end
+
+  let(:logger) { double(:logger, info: nil) }
+  let(:update_subscriber_list) { UpdateSubscriberList.new(document, logger) }
+  let(:subscriber_list_slug) { "subscriber_list_slug" }
+  let(:updateable_parameters) { { "title" => document_title } }
+
+  let(:subscriber_list_attributes) do
+    {
+      "content_id" => content_id,
+      "slug" => subscriber_list_slug,
+      "title" => subscriber_list_title,
+    }
+  end
+
+  describe "#trigger" do
+    describe "with a document for a major or minor content update" do
+      let(:subscriber_list_title) { "An old outdated title" }
+
+      context "subscriber list found by content id" do
+        before { stub_email_alert_api_has_subscriber_list(subscriber_list_attributes) }
+
+        it "logs an attempt to update the subscriber list and triggers the api to update the title" do
+          stub_email_alert_api_has_subscriber_list(subscriber_list_attributes)
+          stub_update_subscriber_list_details(slug: subscriber_list_slug, params: updateable_parameters)
+          update_subscriber_list.trigger
+
+          expect(logger).to have_received(:info).with(
+            "Updating subscriber list: #{subscriber_list_slug}, with: #{updateable_parameters}",
+          )
+        end
+
+        context "subscriber list title matches document list" do
+          let(:subscriber_list_title) { document_title }
+
+          it "logs the outcome and does not attempt an update request" do
+            stub_update_subscriber_list_details(slug: subscriber_list_slug, params: updateable_parameters)
+            update_subscriber_list.trigger
+
+            expect(logger).to have_received(:info).with(
+              "No update needed to subscriber list: #{subscriber_list_slug}",
+            )
+          end
+        end
+
+        context "update attempted with invalid parameters" do
+          before { stub_update_subscriber_list_details_unprocessible_entity(slug: subscriber_list_slug, params: updateable_parameters) }
+
+          it "logs the outcome" do
+            update_subscriber_list.trigger
+
+            expect(logger).to have_received(:info).with(
+              "email-alert-api returned unproessable entity updating subscriber list: #{subscriber_list_slug}, with: #{updateable_parameters}",
+            )
+          end
+        end
+
+        context "subscriber list cannot be found to update by slug" do
+          before { stub_update_subscriber_list_details_not_found(slug: subscriber_list_slug, params: updateable_parameters) }
+
+          it "logs the outcome" do
+            update_subscriber_list.trigger
+
+            expect(logger).to have_received(:info).with(
+              "email-alert-api cannot find subscriber list with slug #{subscriber_list_slug}",
+            )
+          end
+        end
+      end
+
+      context "subscriber list cannot be found by content id" do
+        before { stub_email_alert_api_does_not_have_subscriber_list(subscriber_list_attributes) }
+
+        it "logs the outcome and does not attempt an update request" do
+          update_subscriber_list.trigger
+
+          expect(logger).to have_received(:info).with(
+            "subscriber list not found for content id #{document['content_id']}",
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/IkYegsOt/1225-update-subscriberlist-titles-on-major-minor-publishing-change)

Depends on
=========
https://github.com/alphagov/email-alert-api/pull/1704
(and it's release)

What
====
The GOV.UK Accounts team added a feature where logged in users could
subscribe to email notifications for individual pages.

SubscriberLists store the titles of those pages so that we can:
- Render a list of subscriptions in the user's manage dashboard
- Include the title of the subscriber list in emails alerting the user
that the page has been unpublished. (Especially as there's no-longer a
content item we can query for title at that point).

We record these titles when the SubscriberList is first made, however
there has not been a mechanism to update it. This is a problem as
content titles do change over time.

This PR adds a class we can use to gather information from major and
minor change messages and update the subscriber list titles using a new
[Email Alert API endpoint](1)

Other parts of email-alert-service make calls to services that use GDS
API adaptors. However they seem not to use the test helpers that ship
with the gem through webmock.

A note on test strategy
======================

In previous work we decided to keep the testing strategy consistent
across the repo, and also avoided gds-api-test helpers. Instead we
tested with double and spys.

This got us into a bit of trouble when our parameters and payloads were
not matching the gds-api-adaptors, and reminded us how helpful those
test helpers were.

So we've introduced stubs and webmock for this test, aware this
introduces an inconsistent test strategy.

We intend to go back and refactor tests for the recently introduced
unpublication alert work. And hopefully refactor the rest of the test
suite to.

If you are far in the future and that didn't happen. Sorry! But
hopefully you at least know why these tests don't look like the others.

(1): https://github.com/alphagov/email-alert-api/pull/1704

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
