### PR TITLE
Add missing error and redis config to unpublishing rake task

### DIFF
--- a/lib/tasks/message_queues.rake
+++ b/lib/tasks/message_queues.rake
@@ -43,6 +43,7 @@ namespace :message_queues do
     logger.info "Bound to exchange #{exchange_name} on email_unpublishing queue"
     begin
       GovukError.configure
+      EmailAlertService.services(:redis)
       GovukMessageQueueConsumer::Consumer.new(
         queue_name: "email_unpublishing",
         processor: EmailUnpublishingProcessor.new(logger),

--- a/lib/tasks/message_queues.rake
+++ b/lib/tasks/message_queues.rake
@@ -42,6 +42,7 @@ namespace :message_queues do
   task :unpublishing_consumer do
     logger.info "Bound to exchange #{exchange_name} on email_unpublishing queue"
     begin
+      GovukError.configure
       GovukMessageQueueConsumer::Consumer.new(
         queue_name: "email_unpublishing",
         processor: EmailUnpublishingProcessor.new(logger),


### PR DESCRIPTION
This is something we spotted when doing the update email list work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
