### PR TITLE
Add page summary to unpublished emails

### DIFF
--- a/email_alert_service/models/unpublishing_alert.rb
+++ b/email_alert_service/models/unpublishing_alert.rb
@@ -39,7 +39,7 @@ private
   end
 
   def unpublishing_message
-    UnpublishingMessagePresenter.new(unpublishing_scenario, document).call
+    UnpublishingMessagePresenter.new(unpublishing_scenario, document, subscriber_list).call
   end
 
   def lock_handler

--- a/email_alert_service/presenters/unpublishing_message_presenter.rb
+++ b/email_alert_service/presenters/unpublishing_message_presenter.rb
@@ -9,11 +9,11 @@ class UnpublishingMessagePresenter
 
   def call
     [
-      ["Page summary:\n", subscriber_list["description"]].join,
+      page_summary,
       ["Change made:\n", unpublishing_scenario_note].join,
       ["Time updated:\n", formatted_time].join,
       "^You’ve been automatically unsubscribed from this page because it was removed.",
-    ].join("\n\n")
+    ].compact.join("\n\n")
   end
 
 private
@@ -52,5 +52,15 @@ private
 
     uri.query = URI.encode_www_form(query).presence
     uri.to_s
+  end
+
+  def page_summary
+    description = subscriber_list["description"]
+    if description.nil? || description.empty?
+      GovukError.notify("Recieved unpublishing message with empty or missing description for subscriber list ID: #{subscriber_list['id']}")
+      return nil
+    end
+
+    ["Page summary:\n", description].join
   end
 end

--- a/email_alert_service/presenters/unpublishing_message_presenter.rb
+++ b/email_alert_service/presenters/unpublishing_message_presenter.rb
@@ -1,13 +1,15 @@
 class UnpublishingMessagePresenter
   EMAIL_DATE_FORMAT = "%l:%M%P, %-d %B %Y".freeze
 
-  def initialize(unpublishing_scenario, document)
+  def initialize(unpublishing_scenario, document, subscriber_list)
     @unpublishing_scenario = unpublishing_scenario
     @document = document
+    @subscriber_list = subscriber_list
   end
 
   def call
     [
+      ["Page summary:\n", subscriber_list["description"]].join,
       ["Change made:\n", unpublishing_scenario_note].join,
       ["Time updated:\n", formatted_time].join,
       "^You’ve been automatically unsubscribed from this page because it was removed.",
@@ -16,7 +18,7 @@ class UnpublishingMessagePresenter
 
 private
 
-  attr_reader :unpublishing_scenario, :document
+  attr_reader :unpublishing_scenario, :document, :subscriber_list
 
   def formatted_time
     Time.iso8601(document["public_updated_at"]).strftime(EMAIL_DATE_FORMAT)

--- a/spec/models/unpublishing_alert_spec.rb
+++ b/spec/models/unpublishing_alert_spec.rb
@@ -61,14 +61,7 @@ RSpec.describe UnpublishingAlert do
   let(:unpublishing_alert) { UnpublishingAlert.new(document, logger, unpublishing_scenario) }
   let(:fake_lock_handler) { fake_lock_handler_class.new }
   let(:subscriber_list_slug) { "i_am_a_subscriber_list_slug" }
-  let(:subscriber_list_response) do
-    {
-      "subscriber_list" => {
-        "slug" => subscriber_list_slug,
-        "title" => "Subscriber List Title",
-      },
-    }
-  end
+
   before :each do
     allow(LockHandler).to receive(:new).and_return(fake_lock_handler)
   end
@@ -90,6 +83,7 @@ RSpec.describe UnpublishingAlert do
           stub_email_alert_api_has_subscriber_list(
             "content_id" => content_id,
             "slug" => subscriber_list_slug,
+            "description" => "A subscriber list description.",
           )
         end
 
@@ -154,6 +148,9 @@ RSpec.describe UnpublishingAlert do
       let(:document) { published_in_error_payload }
       let(:email_markdown) do
         <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          A subscriber list description.
+
           Change made:
           This page was removed from GOV.UK because it was published in error. It’s been replaced by: https://www.test.gov.uk/foo/alternative
 
@@ -173,6 +170,9 @@ RSpec.describe UnpublishingAlert do
       let(:document) { published_in_error_payload }
       let(:email_markdown) do
         <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          A subscriber list description.
+
           Change made:
           This page was removed from GOV.UK because it was published in error.
 
@@ -191,6 +191,9 @@ RSpec.describe UnpublishingAlert do
       let(:document) { consolidated_payload }
       let(:email_markdown) do
         <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          A subscriber list description.
+
           Change made:
           This page was removed from GOV.UK. It’s been replaced by https://www.test.gov.uk/government/publications/foobar
 

--- a/spec/presenters/unpublishing_message_presenter_spec.rb
+++ b/spec/presenters/unpublishing_message_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UnpublishingMessagePresenter do
   let(:formatted_time) { time.strftime(UnpublishingMessagePresenter::EMAIL_DATE_FORMAT) }
   let(:alternative_path) { nil }
   let(:website_domain) { "https://www.test.gov.uk" }
-  let(:presenter) { UnpublishingMessagePresenter.new(unpublishing_scenario, document) }
+  let(:presenter) { UnpublishingMessagePresenter.new(unpublishing_scenario, document, subscriber_list) }
 
   let(:published_in_error_payload) do
     {
@@ -49,6 +49,12 @@ RSpec.describe UnpublishingMessagePresenter do
     }
   end
 
+  let(:subscriber_list) do
+    {
+      "description" => "An example page description.",
+    }
+  end
+
   describe "#call" do
     context "presenting a consolidated event" do
       let(:unpublishing_scenario) { :consolidated }
@@ -56,6 +62,9 @@ RSpec.describe UnpublishingMessagePresenter do
 
       it "presents markdown for an email" do
         expected_markdown = <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          An example page description.
+
           Change made:
           This page was removed from GOV.UK. It’s been replaced by #{website_domain}/government/publications/foobar
 
@@ -76,6 +85,9 @@ RSpec.describe UnpublishingMessagePresenter do
 
       it "presents markdown for an email" do
         expected_markdown = <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          An example page description.
+
           Change made:
           This page was removed from GOV.UK because it was published in error. It’s been replaced by: #{website_domain}/foo/alternative
 
@@ -94,6 +106,9 @@ RSpec.describe UnpublishingMessagePresenter do
 
       it "presents markdown for an email" do
         expected_markdown = <<~UNPUBLISHING_MESSAGE
+          Page summary:
+          An example page description.
+
           Change made:
           This page was removed from GOV.UK because it was published in error.
 


### PR DESCRIPTION
We have added descriptions to single page subscription lists which are
the page summary from the content item. Add these descriptions to the
emails about a single page being unpublished so the emails have more
context for users.

Do not merge until the rake task added in [[1]] has been run against
production. This is to ensure all single page subscriber lists have a
non-null description.

[Trello](https://trello.com/c/dm5ZxFVB/1226-pass-through-page-descriptions-to-subscriberlists-on-major-minor-publishing-change)

[1]: https://github.com/alphagov/email-alert-api/pull/1708

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
