### PR TITLE
Update subscriber list description on content change

### DIFF
--- a/email_alert_service/models/update_subscriber_list.rb
+++ b/email_alert_service/models/update_subscriber_list.rb
@@ -38,10 +38,11 @@ private
   def updateable_parameters
     {
       "title" => document["title"],
+      "description" => document["description"],
     }
   end
 
   def parameters_need_updating?
-    subscriber_list["title"] != document["title"]
+    subscriber_list["title"] != document["title"] || subscriber_list["description"] != document["description"]
   end
 end

--- a/spec/models/subscriber_list_details_update_processor_spec.rb
+++ b/spec/models/subscriber_list_details_update_processor_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe SubscriberListDetailsUpdateProcessor do
   let(:content_id) { SecureRandom.uuid }
 
   let(:document_title) { "Example title" }
+  let(:document_description) { "A description" }
   let(:subscriber_list_title) { "An old outdated title" }
   let(:subscriber_list_slug) { "subscriber_list_slug" }
 
@@ -29,6 +30,7 @@ RSpec.describe SubscriberListDetailsUpdateProcessor do
       "content_id" => content_id,
       "title" => document_title,
       "locale" => "en",
+      "description" => document_description,
     }
   end
 
@@ -37,10 +39,11 @@ RSpec.describe SubscriberListDetailsUpdateProcessor do
       "content_id" => content_id,
       "slug" => subscriber_list_slug,
       "title" => subscriber_list_title,
+      "description" => document_description,
     }
   end
 
-  let(:updateable_parameters) { { "title" => document_title } }
+  let(:updateable_parameters) { { "title" => document_title, "description" => document_description } }
 
   describe "#process" do
     it "acknowledges and triggers the update for a correctly formatted document" do


### PR DESCRIPTION
Extend the processors added in #493 to also check if the subscriber list
description has changed with a major or minor content change. If it has,
send the new version to email alert API.

These descriptions will be included in the emails sent when a page is
unpublished, so it's important that they're kept up to date.

Depends on https://github.com/alphagov/email-alert-api/pull/1709 and having run the rake task in https://github.com/alphagov/email-alert-api/pull/1708

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
