### PR TITLE
Update redis gem, update to  pipeline block parameter as required.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -124,7 +125,10 @@ GEM
     raindrops (0.20.0)
     rake (13.0.6)
     rbtree (0.4.5)
-    redis (4.8.0)
+    redis (5.0.3)
+      redis-client (>= 0.7.4)
+    redis-client (0.8.0)
+      connection_pool
     redis-namespace (1.9.0)
       redis (>= 4)
     regexp_parser (2.5.0)

--- a/email_alert_service/models/lock_handler.rb
+++ b/email_alert_service/models/lock_handler.rb
@@ -47,10 +47,10 @@ private
 
   def try_acquire_lock
     temp_key = "temp:#{SecureRandom.base64(18)}"
-    redis.multi {
-      redis.setex temp_key, LOCK_PERIOD_IN_SECONDS, lock_name
-      redis.renamenx temp_key, lock_key
-      redis.del temp_key
+    redis.multi { |pipeline|
+      pipeline.setex temp_key, LOCK_PERIOD_IN_SECONDS, lock_name
+      pipeline.renamenx temp_key, lock_key
+      pipeline.del temp_key
     }[1]
   end
 


### PR DESCRIPTION
Allows updates to Redis 5+

In redis-rb 5+, .multi and .pipeline blocks must have arity 1, and use that method for the pipelined/transaction methods called in the block.

https://trello.com/c/DM2bDFAB/1508-upgrade-redis-421-to-502-in-email-alert-service

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
