### PR TITLE
Add document collection ids to the links payload for email alert api

### DIFF
--- a/email_alert_service/models/document_links.rb
+++ b/email_alert_service/models/document_links.rb
@@ -1,0 +1,25 @@
+class DocumentLinks
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def self.call(args)
+    new(args).links
+  end
+
+  def links
+    document.fetch("links", {}).merge("taxon_tree" => taxon_tree)
+  end
+
+private
+
+  def taxons
+    document.dig("expanded_links", "taxons").to_a
+  end
+
+  def taxon_tree
+    TaxonTree.ancestors(taxons)
+  end
+end

--- a/email_alert_service/models/document_links.rb
+++ b/email_alert_service/models/document_links.rb
@@ -10,13 +10,24 @@ class DocumentLinks
   end
 
   def links
-    document.fetch("links", {}).merge("taxon_tree" => taxon_tree)
+    document.fetch("links", {}).merge(
+      "taxon_tree" => taxon_tree,
+      "document_collections" => document_collection_ids,
+    )
   end
 
 private
 
   def taxons
     document.dig("expanded_links", "taxons").to_a
+  end
+
+  def document_collections
+    document.dig("expanded_links", "document_collections").to_a
+  end
+
+  def document_collection_ids
+    document_collections.map { |o| o["content_id"] }
   end
 
   def taxon_tree

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -27,7 +27,7 @@ class EmailAlert
       "change_note" => change_note,
       "subject" => document["title"],
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
-      "links" => document_links,
+      "links" => strip_empty_arrays(document_links),
       "document_type" => document_type,
       "email_document_supertype" => document["email_document_supertype"],
       "government_document_supertype" => document["government_document_supertype"],
@@ -58,13 +58,7 @@ private
   end
 
   def document_links
-    strip_empty_arrays(
-      document.fetch("links", {}).merge("taxon_tree" => taxon_tree),
-    )
-  end
-
-  def taxon_tree
-    TaxonTree.ancestors(document.dig("expanded_links", "taxons").to_a)
+    DocumentLinks.call(document)
   end
 
   def document_type

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -181,6 +181,32 @@ RSpec.describe EmailAlert do
       end
     end
 
+    context "document collection links are present" do
+      before do
+        document.merge!(
+          "expanded_links" => {
+            "document_collections" => [
+              {
+                "content_id" => "uuid-of-document-collection",
+                "title" => "Document Collection Title",
+                "links" => {
+                  "documents" => [
+                    { "content_id" => content_id, "links" => {} },
+                  ],
+                },
+              },
+            ],
+          },
+        )
+      end
+
+      it "formats the message to include document collection ids" do
+        links_hash = email_alert.format_for_email_api["links"]
+
+        expect(links_hash["document_collections"]).to eq %w[uuid-of-document-collection]
+      end
+    end
+
     context "with a travel advice" do
       before do
         document.merge!("document_type" => "travel_advice")


### PR DESCRIPTION

This is needed to support
https://github.com/alphagov/email-alert-api/pull/1803

When a user signs up to alerts on a document collection, research has shown an
expectation of being notified when changes are made to documents within that collection.

The message that publishing API puts onto rabbit contains the expanded links (see eg here
https://deploy.integration.publishing.service.gov.uk/job/run-rake-task/305143/console) but
email alert service only forwards some of this to Email Alert API:

  - To support topic taxonomy based emails, this application creates a custom `taxon_tree`
attribute populated from content_ids in the taxon attribute of expanded links.
  - Following that pattern, this commit adds a document collection attribute, populated
with content ids plucked from the document collection attribute of expanded links

Trello card: https://trello.com/c/tJvdhfdd/1455-support-topic-like-subscriptions-for-document-collections-email-alert-api-s, [Jira issue NAV-5609](https://gov-uk.atlassian.net/browse/NAV-5609)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
