### PR TITLE
Add reverse links

### DIFF
--- a/email_alert_service/models/document_links.rb
+++ b/email_alert_service/models/document_links.rb
@@ -1,0 +1,25 @@
+class DocumentLinks
+  attr_reader :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def self.call(args)
+    new(args).links
+  end
+
+  def links
+    document.fetch("links", {}).merge("taxon_tree" => taxon_tree)
+  end
+
+private
+
+  def taxons
+    document.dig("expanded_links", "taxons").to_a
+  end
+
+  def taxon_tree
+    TaxonTree.ancestors(taxons)
+  end
+end

--- a/email_alert_service/models/document_links.rb
+++ b/email_alert_service/models/document_links.rb
@@ -5,18 +5,34 @@ class DocumentLinks
     @document = document
   end
 
-  def self.call(args)
-    new(args).links
+  def self.call(...)
+    new(...).links
   end
 
   def links
-    document.fetch("links", {}).merge("taxon_tree" => taxon_tree)
+    reverse_links_hash.merge("taxon_tree" => taxon_tree)
   end
 
 private
 
   def taxons
     document.dig("expanded_links", "taxons").to_a
+  end
+
+  def reverse_links_hash
+    expanded_links_keys.each_with_object({}) do |key, hash|
+      expanded_links_values = document.dig("expanded_links", key)
+      content_ids = expanded_links_values.map { |i| i["content_id"] }
+      hash[key] = content_ids
+    end
+  end
+
+  def raw_expanded_links_keys
+    document.fetch("expanded_links", {}).keys
+  end
+
+  def expanded_links_keys
+    raw_expanded_links_keys.tap { |k| k.delete("available_translations") }
   end
 
   def taxon_tree

--- a/email_alert_service/models/email_alert.rb
+++ b/email_alert_service/models/email_alert.rb
@@ -27,7 +27,7 @@ class EmailAlert
       "change_note" => change_note,
       "subject" => document["title"],
       "tags" => strip_empty_arrays(document.fetch("details", {}).fetch("tags", {})),
-      "links" => document_links,
+      "links" => strip_empty_arrays(document_links),
       "document_type" => document_type,
       "email_document_supertype" => document["email_document_supertype"],
       "government_document_supertype" => document["government_document_supertype"],
@@ -58,13 +58,7 @@ private
   end
 
   def document_links
-    strip_empty_arrays(
-      document.fetch("links", {}).merge("taxon_tree" => taxon_tree),
-    )
-  end
-
-  def taxon_tree
-    TaxonTree.ancestors(document.dig("expanded_links", "taxons").to_a)
+    DocumentLinks.call(document)
   end
 
   def document_type


### PR DESCRIPTION
https://trello.com/c/tJvdhfdd/1455-support-topic-like-subscriptions-for-document-collections-email-alert-api-m, [Jira issue NAV-5609](https://gov-uk.atlassian.net/browse/NAV-5609)

## Add reverse links to the payload for Email Alert API

See commit messages for more information.

#### `ContentChange` created in Email Alert API using main branch of email alert service
<img width="1438" alt="Screenshot 2022-11-29 at 14 11 38" src="https://user-images.githubusercontent.com/17908089/204551560-441acd7f-3294-43d5-b3e4-081d3758cb2b.png">

#### The extended `ContentChange` created in Email Alert API using this branch of email alert service
Note the new `document_collections` key in the links hash.

<img width="1674" alt="Screenshot 2022-11-29 at 14 20 44" src="https://user-images.githubusercontent.com/17908089/204553949-65a450fc-ed75-4bc5-b050-e3e98ec7ac67.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
