### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,15 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+features
+log
+node_modules
+script
+spec
+test
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,23 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
- 
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY . .
 
-COPY . /app
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=email-alert-service
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD bundle exec rake message_queues:major_change_consumer
+CMD ["rake", "message_queues:major_change_consumer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 
 
 FROM $base_image
@@ -17,6 +18,7 @@ ENV GOVUK_APP_NAME=email-alert-service
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "bootsnap", require: false
 gem "bunny"
 gem "gds-api-adapters"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     amq-protocol (2.3.2)
     ast (2.4.2)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     builder (3.2.4)
     bunny (2.20.2)
       amq-protocol (~> 2.3, >= 2.3.1)
@@ -82,6 +84,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_portile2 (2.8.1)
     minitest (5.17.0)
+    msgpack (1.6.0)
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
@@ -225,6 +228,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bootsnap
   bunny
   gds-api-adapters
   govuk_app_config

--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -1,3 +1,10 @@
+require "bundler/setup"
+require "bootsnap"
+Bootsnap.setup(
+  cache_dir: ENV.fetch("BOOTSNAP_CACHE_DIR", "tmp/cache"),
+  development_mode: ENV["RACK_ENV"] == "development",
+)
+
 require_relative "../email_alert_service/config"
 
 module EmailAlertService
@@ -13,7 +20,6 @@ end
   $LOAD_PATH << path.to_s
 end
 
-require "bundler/setup"
 Bundler.require(:default, EmailAlertService.config.environment)
 
 require "govuk_app_config"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Update .dockerignore.

Tested: app boots successfully with `docker run`.
