### PR TITLE
Add a single entrypoint that runs all consumers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app
-CMD ["rake", "message_queues:major_change_consumer"]
+CMD ["bin/email-alert-service"]

--- a/bin/email-alert-service
+++ b/bin/email-alert-service
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+require_relative "../email_alert_service/environment"
+
+EmailAlertService.run_processor(MajorChangeMessageProcessor, "email_alert_service")
+EmailAlertService.run_processor(EmailUnpublishingProcessor, "email_unpublishing")
+EmailAlertService.run_processor(SubscriberListDetailsUpdateProcessor, "subscriber_list_details_update_major")
+EmailAlertService.run_processor(SubscriberListDetailsUpdateProcessor, "subscriber_list_details_update_minor")
+Process.wait  # Exit with error status if any child process exits.
+exit 1

--- a/email_alert_service/config.rb
+++ b/email_alert_service/config.rb
@@ -24,6 +24,7 @@ module EmailAlertService
     end
 
     def logger
+      $stdout.sync = true
       @logger ||= Logger.new($stdout)
     end
 

--- a/email_alert_service/environment.rb
+++ b/email_alert_service/environment.rb
@@ -6,20 +6,31 @@ Bootsnap.setup(
 )
 
 require_relative "../config/prometheus"
-require_relative "../email_alert_service/config"
+require_relative "config"
 
 module EmailAlertService
   def self.config
     EmailAlertService::Config.new(ENV["GOVUK_ENV"])
   end
+
+  def self.run_processor(processor_class, queue_name)
+    Process.fork do
+      Process.setproctitle("#{$PROGRAM_NAME} [#{queue_name}]")
+      logger = EmailAlertService.config.logger
+      exchange_name = EmailAlertService.config.rabbitmq[:exchange]
+      logger.info "Starting #{processor_class} for queue #{queue_name} on exchange #{exchange_name}"
+      GovukError.configure
+      EmailAlertService.services(:redis)
+      processor = processor_class.new(logger)
+      GovukMessageQueueConsumer::Consumer.new(queue_name:, processor:, logger:).run
+    end
+  end
 end
 
-[
-  EmailAlertService.config.app_root,
+$LOAD_PATH.append(
+  EmailAlertService.config.app_root.to_s,
   "#{EmailAlertService.config.app_root}/email_alert_service",
-].each do |path|
-  $LOAD_PATH << path.to_s
-end
+)
 
 Bundler.require(:default, EmailAlertService.config.environment)
 

--- a/lib/tasks/message_queues.rake
+++ b/lib/tasks/message_queues.rake
@@ -18,6 +18,8 @@ namespace :message_queues do
     end
   end
 
+  # TODO(#623): remove *_consumer and run_processor_worker once
+  # email-alert-service is running in Kubernetes in production.
   desc "Run worker to consume major change messages from rabbitmq"
   task :major_change_consumer do
     run_processor_worker(


### PR DESCRIPTION
On Kubernetes it's simpler and more efficient to run the four consumer processes in the same Pod than to run a separate Deployment for each.                                 
    
The simplest way to do this is to fork and have the parent process exit if any of the child processes exit.                                
    
The main motivation for this change is to avoid having to add weirdness to the Prometheus scrape config and run [prometheus_exporter] on multiple ports in the same Pod, which is what we'd have to do if we were to keep the application as-is.
    
Avoiding the (mis)use of Rake to start the application simplifies the startup process and makes it easier to understand the control flow during initialisation. For example it turns out that Bootsnap was being initialised much later than it's supposed to be, even though from reading the source code it looked like the first thing called on startup.

This doesn't change the way the app runs on EC2; it still runs as four separate Rake tasks there.

Co-authored-by: @dj-maisy 


### Alternatives considered

If we were to keep the existing model and run four Rake containers in the same Pod then we'd need to assign four separate ports for the Prometheus metrics in order for them not to clash, which just seems overly complex vs. just forking a process for each consumer loop. If [prometheus_exporter] could be made to run as a sidecar container alongside the four Rake containers then we could have a single port for `/metrics` and this would be a viable (though somewhat more complex) option.
    
The other alternative of running a separate Deployment for each message type would use 3-4x the resources, given the very low rates of messages on three out of the four queues. So that'd be worse for running costs and CO₂e, as well as being slightly more operationally complex.

[prometheus_exporter]: https://github.com/discourse/prometheus_exporter    


### Follow-up work

#623 clears up the (soon to be) dead code after we decommission the EC2 deployment.