### PR TITLE
Remove specialist topics from email-alert-service

### DIFF
--- a/email_alert_service/models/major_change_message_processor.rb
+++ b/email_alert_service/models/major_change_message_processor.rb
@@ -65,7 +65,6 @@ private
     # let through anything for which Whitehall would have sent emails to
     # organisation-based lists if none of these other attributes exist on it.
     supported_attributes = %w[
-      topics
       policies
       service_manual_topics
       taxons

--- a/spec/models/email_alert_spec.rb
+++ b/spec/models/email_alert_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe EmailAlert do
       "details" => {
         "tags" => {
           "browse_pages" => ["tax/vat"],
-          "topics" => ["oil-and-gas/licensing"],
           "some_other_missing_tags" => [],
         },
         "change_history" => [
@@ -110,7 +109,6 @@ RSpec.describe EmailAlert do
         "publishing_app" => "Whitehall",
         "tags" => {
           "browse_pages" => ["tax/vat"],
-          "topics" => ["oil-and-gas/licensing"],
         },
         "links" => {},
         "document_type" => "example_document",
@@ -128,13 +126,13 @@ RSpec.describe EmailAlert do
       before do
         document.merge!(
           "links" => {
-            "topics" => %w[uuid-888],
+            "world_locations" => %w[uuid-888],
           },
           "expanded_links" => {
-            "topics" => [
+            "world_locations" => [
               {
                 "content_id" => "uuid-888",
-                "title" => "This topic",
+                "title" => "This world location",
               },
             ],
           },
@@ -144,7 +142,7 @@ RSpec.describe EmailAlert do
       it "formats the message to include the parent link" do
         expect(email_alert.format_for_email_api).to include(
           "links" => {
-            "topics" => %w[uuid-888],
+            "world_locations" => %w[uuid-888],
           },
         )
       end
@@ -152,12 +150,12 @@ RSpec.describe EmailAlert do
 
     context "blank tags are present" do
       before do
-        document["links"] = { "topics" => [] }
-        document["details"]["tags"].merge!("topics" => [])
+        document["links"] = { "world_locations" => [] }
+        document["details"]["tags"].merge!("roles" => [])
       end
 
       it "strips these out" do
-        expect(email_alert.format_for_email_api["tags"]).not_to include("topics")
+        expect(email_alert.format_for_email_api["tags"]).not_to include("roles")
       end
     end
 
@@ -206,9 +204,9 @@ RSpec.describe EmailAlert do
                 "title" => "Document Collection Title",
                 "links" => { "documents" => [{ "content_id" => content_id, "links" => {} }] } },
             ],
-            "policies" => [
-              { "content_id" => "uuid-of-policy-paper",
-                "title" => "Policy Paper Title",
+            "world_locations" => [
+              { "content_id" => "uuid-of-location",
+                "title" => "World Location Title",
                 "links" => { "working_groups" => [{ "content_id" => content_id, "links" => {} }] } },
             ],
             "available_translations" => [
@@ -223,7 +221,7 @@ RSpec.describe EmailAlert do
       it "formats the message to include content ids of all the reverse linked documents except available_translations" do
         expected = {
           "document_collections" => %w[uuid-of-document-collection],
-          "policies" => %w[uuid-of-policy-paper],
+          "world_locations" => %w[uuid-of-location],
         }
 
         expect(email_alert.format_for_email_api["links"]).to eq(expected)

--- a/spec/models/major_change_message_processor_spec.rb
+++ b/spec/models/major_change_message_processor_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe MajorChangeMessageProcessor do
       "details" => {
         "change_history" => change_history,
         "tags" => {
-          "topics" => ["example topic"],
+          "roles" => %w[prime-minister],
         },
       },
       "links" => {
-        "topics" => %w[example-topic-uuid],
+        "world_locations" => %w[example-location-uuid],
       },
     }
   end
@@ -75,12 +75,7 @@ RSpec.describe MajorChangeMessageProcessor do
       message_acknowledged
     end
 
-    context "document tagged with a policy" do
-      before do
-        good_document["details"]["tags"] = { "policies" => ["example policy"] }
-        good_document["links"] = { "policies" => %w[example-policy-uuid] }
-      end
-
+    context "document tagged with a role" do
       it "acknowledges and triggers the email" do
         processor.process(message)
 
@@ -104,7 +99,7 @@ RSpec.describe MajorChangeMessageProcessor do
 
     context "document with no tags in its links hash" do
       before do
-        good_document["links"].delete("topics")
+        good_document["links"].delete("world_locations")
       end
 
       it "still acknowledges and triggers the email" do
@@ -117,8 +112,8 @@ RSpec.describe MajorChangeMessageProcessor do
 
     context "document with empty tags" do
       before do
-        good_document["details"]["tags"] = { "topics" => [] }
-        good_document["links"] = { "topics" => [] }
+        good_document["details"]["tags"] = { "roles" => [] }
+        good_document["links"] = { "world_locations" => [] }
       end
 
       it "acknowledges but doesn't trigger the email" do
@@ -131,7 +126,7 @@ RSpec.describe MajorChangeMessageProcessor do
 
     context "document with missing tag fields" do
       before do
-        good_document["links"].delete("topics")
+        good_document["links"].delete("world_locations")
         good_document["details"].delete("tags")
       end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove specialist topics from the supported attributes in  email-alert-service.

Please investigate and make a note on the PR about what the \`:topic\`  field is referring to here: [https://github.com/alphagov/email-alert-service/blob/53ce12e4ea8f5643dbb3051c8ec5c9651afa8b6b/lib/tasks/message_queues.rake#L10C45-L10C51](https://github.com/alphagov/email-alert-service/blob/53ce12e4ea8f5643dbb3051c8ec5c9651afa8b6b/lib/tasks/message_queues.rake#L10C45-L10C51 "smartCard-inline")

## Why

Retiring specialist topics.

[Trello card](https://trello.com/c/hIUgTP0C/2497-remove-specialist-topics-from-email-alert-service-s-m), [Jira issue NAV-12379](https://gov-uk.atlassian.net/browse/NAV-12379)