### PR TITLE
Add dependabot cooldown periods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - govuk_*
+        - plek
+        - rubocop-govuk


### PR DESCRIPTION
- To add cooldown periods for bundler(3 days) with exclusion for alphagov gems that have their own cooldown as per the documentation - https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
