### PR TITLE
Change Slack notification channel for failures

### DIFF
--- a/.github/workflows/notify-slack-on-failure.yml
+++ b/.github/workflows/notify-slack-on-failure.yml
@@ -20,5 +20,5 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
         with:
           slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
-          channel: govuk-patterns-and-pages-tech
+          channel: govuk-navigation-tech
           message: "Github was unable to complete the CI or Deploy Actions workflow - requires further investigation."


### PR DESCRIPTION
Route test failure alerts to thje navigation team as they are the new owners of this app

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
